### PR TITLE
Switch from `PackageInfo_cabal_gild` to `Paths_cabal_gild`

### DIFF
--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -49,8 +49,8 @@ common executable
 library
   import:          library
   hs-source-dirs:  source/library
-  other-modules:   PackageInfo_cabal_gild
-  autogen-modules: PackageInfo_cabal_gild
+  other-modules:   Paths_cabal_gild
+  autogen-modules: Paths_cabal_gild
 
   -- GHC boot libraries
   build-depends:

--- a/source/library/CabalGild/Main.hs
+++ b/source/library/CabalGild/Main.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString as BS
 import Data.Traversable (for)
 import Data.Version (showVersion)
 import qualified Options.Applicative as O
-import PackageInfo_cabal_gild (version)
+import Paths_cabal_gild (version)
 import System.Exit (exitFailure)
 import System.FilePath (takeDirectory)
 import System.IO (hPutStrLn, stderr)


### PR DESCRIPTION
This effectively reverts 88cf9726f7c2e8c6f670b70de096b33cf9011d0b.

See <https://github.com/tfausak/cabal-gild/pull/1#issuecomment-1913844637>.