### PR TITLE
Allow setting input file when reading from STDIN

### DIFF
--- a/source/library/CabalGild/Options.hs
+++ b/source/library/CabalGild/Options.hs
@@ -27,7 +27,8 @@ data Options = Options
     optTabular :: !Bool,
     optCabalFile :: !Bool,
     optSpecVersion :: !C.CabalSpecVersion,
-    optMode :: !Mode
+    optMode :: !Mode,
+    optStdinInputFile :: !(Maybe FilePath)
   }
   deriving (Show)
 
@@ -39,7 +40,8 @@ defaultOptions =
       optTabular = True,
       optCabalFile = True,
       optSpecVersion = C.cabalSpecLatest,
-      optMode = ModeStdout
+      optMode = ModeStdout,
+      optStdinInputFile = Nothing
     }
 
 newtype OptionsMorphism = OM (Options -> Options)


### PR DESCRIPTION
This is the same as https://github.com/phadej/cabal-fmt/pull/82. That was an alternative to https://github.com/phadej/cabal-fmt/pull/65. Both of those fixed https://github.com/phadej/cabal-fmt/issues/51. 

This adds a new command-line option: `--stdin-input-file=FILE`. When reading input from STDIN, the given `FILE` path will be used. This allows features like the `-- cabal-gild: expand DIR` pragma to work. 