### PR TITLE
Discover literate Haskell files

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Each pragma starts with `-- cabal-gild:`. Pragmas must be the last comment
 before a field.
 
 - `-- cabal-gild: discover DIRECTORY`: This pragma will discover any Haskell
-  files (`*.hs`) in the given directory and use those to populate the list of
-  modules. For example, given this input:
+  files (`*.hs` or `*.lhs`) in the given directory and use those to populate
+  the list of modules. For example, given this input:
 
   ``` cabal
   library

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -65,7 +65,7 @@ field p f = case f of
 stripAnyExtension :: Set.Set String -> FilePath -> Maybe String
 stripAnyExtension es p =
   Maybe.listToMaybe
-    . Maybe.mapMaybe (flip FilePath.stripExtension p)
+    . Maybe.mapMaybe (`FilePath.stripExtension` p)
     $ Set.toList es
 
 -- | A map from field names to the set of extensions that should be discovered

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -6,9 +6,9 @@ import qualified CabalGild.Extra.Name as Name
 import qualified CabalGild.Extra.String as String
 import qualified CabalGild.Type.Comment as Comment
 import qualified CabalGild.Type.Pragma as Pragma
-import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.Maybe as MaybeT
+import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified Distribution.Fields as Fields
@@ -46,7 +46,7 @@ field ::
   m (Fields.Field [Comment.Comment a])
 field p f = case f of
   Fields.Field n _ -> fmap (Maybe.fromMaybe f) . MaybeT.runMaybeT $ do
-    Monad.guard $ Set.member (Name.value n) relevantFieldNames
+    es <- hoistMaybe . Map.lookup (Name.value n) $ extensions
     c <- hoistMaybe . Utils.safeLast $ Name.annotation n
     x <- hoistMaybe . Parsec.simpleParsecBS $ Comment.value c
     y <- case x of
@@ -57,19 +57,27 @@ field p f = case f of
       . Fields.Field n
       . fmap (ModuleName.toFieldLine [])
       . Maybe.mapMaybe (ModuleName.fromFilePath . FilePath.makeRelative d)
-      $ Maybe.mapMaybe (FilePath.stripExtension "hs") fs
+      $ Maybe.mapMaybe (stripAnyExtension es) fs
   Fields.Section n sas fs -> Fields.Section n sas <$> fields p fs
 
--- | These are the names of the fields that can have this action applied to
--- them.
-relevantFieldNames :: Set.Set Fields.FieldName
-relevantFieldNames =
-  Set.fromList $
-    fmap
-      String.toUtf8
-      [ "exposed-modules",
-        "other-modules"
-      ]
+-- | Attempts to strip any of the given extensions from the file path. If any
+-- of them succeed, the result is returned. Otherwise 'Nothing' is returned.
+stripAnyExtension :: Set.Set String -> FilePath -> Maybe String
+stripAnyExtension es p =
+  Maybe.listToMaybe
+    . Maybe.mapMaybe (flip FilePath.stripExtension p)
+    $ Set.toList es
+
+-- | A map from field names to the set of extensions that should be discovered
+-- for that field.
+extensions :: Map.Map Fields.FieldName (Set.Set String)
+extensions =
+  let (=:) :: String -> [String] -> (Fields.FieldName, Set.Set String)
+      k =: v = (String.toUtf8 k, Set.fromList v)
+   in Map.fromList
+        [ "exposed-modules" =: ["hs"],
+          "other-modules" =: ["hs"]
+        ]
 
 -- | This was added in @transformers-0.6.0.0@. See
 -- <https://hub.darcs.net/ross/transformers/issue/49>.

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -75,8 +75,8 @@ extensions =
   let (=:) :: String -> [String] -> (Fields.FieldName, Set.Set String)
       k =: v = (String.toUtf8 k, Set.fromList v)
    in Map.fromList
-        [ "exposed-modules" =: ["hs"],
-          "other-modules" =: ["hs"]
+        [ "exposed-modules" =: ["hs", "lhs"],
+          "other-modules" =: ["hs", "lhs"]
         ]
 
 -- | This was added in @transformers-0.6.0.0@. See

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -774,6 +774,12 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n    N\n"
 
+  Hspec.it "discovers a literate haskell module" $ do
+    expectDiscover
+      ["M.lhs"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
   Hspec.it "ignores discover pragma separated by comment" $ do
     expectGilded
       "library\n -- cabal-gild: discover .\n -- foo\n exposed-modules: M"

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -751,52 +751,28 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "custom-setup\n  setup-depends:\n    a,\n    b\n"
 
   Hspec.it "discovers an exposed module" $ do
-    let (a, s, w) =
-          runTest
-            (Gild.mainWith "" [])
-            ( Map.singleton Nothing (String.toUtf8 "library\n -- cabal-gild: discover .\n exposed-modules:"),
-              Map.singleton (FilePath.combine "." ".") ["M.hs"]
-            )
-            Map.empty
-    a `Hspec.shouldBe` Right ()
-    w `Hspec.shouldBe` []
-    s `Hspec.shouldBe` Map.singleton Nothing (String.toUtf8 "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n")
+    expectDiscover
+      ["M.hs"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers an other module" $ do
-    let (a, s, w) =
-          runTest
-            (Gild.mainWith "" [])
-            ( Map.singleton Nothing (String.toUtf8 "library\n -- cabal-gild: discover .\n other-modules:"),
-              Map.singleton (FilePath.combine "." ".") ["M.hs"]
-            )
-            Map.empty
-    a `Hspec.shouldBe` Right ()
-    w `Hspec.shouldBe` []
-    s `Hspec.shouldBe` Map.singleton Nothing (String.toUtf8 "library\n  -- cabal-gild: discover .\n  other-modules: M\n")
+    expectDiscover
+      ["M.hs"]
+      "library\n -- cabal-gild: discover .\n other-modules:"
+      "library\n  -- cabal-gild: discover .\n  other-modules: M\n"
 
   Hspec.it "discovers a nested module" $ do
-    let (a, s, w) =
-          runTest
-            (Gild.mainWith "" [])
-            ( Map.singleton Nothing (String.toUtf8 "library\n -- cabal-gild: discover .\n exposed-modules:"),
-              Map.singleton (FilePath.combine "." ".") [FilePath.combine "N" "O.hs"]
-            )
-            Map.empty
-    a `Hspec.shouldBe` Right ()
-    w `Hspec.shouldBe` []
-    s `Hspec.shouldBe` Map.singleton Nothing (String.toUtf8 "library\n  -- cabal-gild: discover .\n  exposed-modules: N.O\n")
+    expectDiscover
+      [FilePath.combine "N" "O.hs"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: N.O\n"
 
   Hspec.it "discovers multiple modules" $ do
-    let (a, s, w) =
-          runTest
-            (Gild.mainWith "" [])
-            ( Map.singleton Nothing (String.toUtf8 "library\n -- cabal-gild: discover .\n exposed-modules:"),
-              Map.singleton (FilePath.combine "." ".") ["M.hs", "N.hs"]
-            )
-            Map.empty
-    a `Hspec.shouldBe` Right ()
-    w `Hspec.shouldBe` []
-    s `Hspec.shouldBe` Map.singleton Nothing (String.toUtf8 "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n    N\n")
+    expectDiscover
+      ["M.hs", "N.hs"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n    N\n"
 
   Hspec.it "ignores discover pragma separated by comment" $ do
     expectGilded
@@ -842,6 +818,22 @@ expectStable input = do
     [(Nothing, x)] -> pure x
     _ -> fail $ "impossible: " <> show s
   output `Hspec.shouldBe` input
+
+expectDiscover :: [FilePath] -> String -> String -> Hspec.Expectation
+expectDiscover files input expected = do
+  let (a, s, w) =
+        runTest
+          (Gild.mainWith "" [])
+          ( Map.singleton Nothing (String.toUtf8 input),
+            Map.singleton (FilePath.combine "." ".") files
+          )
+          Map.empty
+  a `Hspec.shouldBe` Right ()
+  w `Hspec.shouldBe` []
+  actual <- case Map.toList s of
+    [(Nothing, x)] -> pure x
+    _ -> fail $ "impossible: " <> show s
+  actual `Hspec.shouldBe` String.toUtf8 expected
 
 newtype Problem = Problem
   { unProblem :: Exception.SomeException


### PR DESCRIPTION
This addresses part of #14. It updates the discover pragma to find literate Haskell files (`*.lhs`) in addition to normal Haskell files (`*.hs`). 