### PR TITLE
Discover modules from preprocessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Each pragma starts with `-- cabal-gild:`. Pragmas must be the last comment
 before a field.
 
 - `-- cabal-gild: discover DIRECTORY`: This pragma will discover any Haskell
-  files (`*.hs` or `*.lhs`) in the given directory and use those to populate
-  the list of modules. For example, given this input:
+  files in the given directory and use those to populate the list of modules.
+  For example, given this input:
 
   ``` cabal
   library
@@ -186,3 +186,6 @@ before a field.
   Any existing modules in the list will be ignored. The entire field will be
   replaced. This means adding, removing, and renaming modules should be handled
   automatically.
+
+  This pragma searches for files with any of the following extensions: `*.chs`,
+  `*.cpphs`, `*.gc`, `*.hs`, `*.hsc`, `*.lhs`, `*.ly`, `*.x`, or `*.y`,

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -70,11 +70,23 @@ stripAnyExtension es p =
 
 -- | A map from field names to the set of extensions that should be discovered
 -- for that field.
+--
+-- <https://cabal.readthedocs.io/en/3.10/cabal-package.html#modules-and-preprocessors>
 extensions :: Map.Map Fields.FieldName (Set.Set String)
 extensions =
   let (=:) :: String -> [String] -> (Fields.FieldName, Set.Set String)
       k =: v = (String.toUtf8 k, Set.fromList v)
-      hs = ["hs", "lhs"]
+      hs =
+        [ "chs",
+          "cpphs",
+          "gc",
+          "hs",
+          "hsc",
+          "lhs",
+          "ly",
+          "x",
+          "y"
+        ]
    in Map.fromList
         [ "exposed-modules" =: hs,
           "other-modules" =: hs

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -6,9 +6,9 @@ import qualified CabalGild.Extra.Name as Name
 import qualified CabalGild.Extra.String as String
 import qualified CabalGild.Type.Comment as Comment
 import qualified CabalGild.Type.Pragma as Pragma
+import qualified Control.Monad as Monad
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.Maybe as MaybeT
-import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified Distribution.Fields as Fields
@@ -46,7 +46,7 @@ field ::
   m (Fields.Field [Comment.Comment a])
 field p f = case f of
   Fields.Field n _ -> fmap (Maybe.fromMaybe f) . MaybeT.runMaybeT $ do
-    es <- hoistMaybe . Map.lookup (Name.value n) $ extensions
+    Monad.guard $ Set.member (Name.value n) relevantFieldNames
     c <- hoistMaybe . Utils.safeLast $ Name.annotation n
     x <- hoistMaybe . Parsec.simpleParsecBS $ Comment.value c
     y <- case x of
@@ -57,8 +57,19 @@ field p f = case f of
       . Fields.Field n
       . fmap (ModuleName.toFieldLine [])
       . Maybe.mapMaybe (ModuleName.fromFilePath . FilePath.makeRelative d)
-      $ Maybe.mapMaybe (stripAnyExtension es) fs
+      $ Maybe.mapMaybe (stripAnyExtension extensions) fs
   Fields.Section n sas fs -> Fields.Section n sas <$> fields p fs
+
+-- | These are the names of the fields that can have this action applied to
+-- them.
+relevantFieldNames :: Set.Set Fields.FieldName
+relevantFieldNames =
+  Set.fromList $
+    fmap
+      String.toUtf8
+      [ "exposed-modules",
+        "other-modules"
+      ]
 
 -- | Attempts to strip any of the given extensions from the file path. If any
 -- of them succeed, the result is returned. Otherwise 'Nothing' is returned.
@@ -68,29 +79,23 @@ stripAnyExtension es p =
     . Maybe.mapMaybe (`FilePath.stripExtension` p)
     $ Set.toList es
 
--- | A map from field names to the set of extensions that should be discovered
--- for that field.
+-- | The set of extensions that should be discovered by this pragma. Any file
+-- with one of these extensions will be discovered.
 --
 -- <https://cabal.readthedocs.io/en/3.10/cabal-package.html#modules-and-preprocessors>
-extensions :: Map.Map Fields.FieldName (Set.Set String)
+extensions :: Set.Set String
 extensions =
-  let (=:) :: String -> [String] -> (Fields.FieldName, Set.Set String)
-      k =: v = (String.toUtf8 k, Set.fromList v)
-      hs =
-        [ "chs",
-          "cpphs",
-          "gc",
-          "hs",
-          "hsc",
-          "lhs",
-          "ly",
-          "x",
-          "y"
-        ]
-   in Map.fromList
-        [ "exposed-modules" =: hs,
-          "other-modules" =: hs
-        ]
+  Set.fromList
+    [ "chs",
+      "cpphs",
+      "gc",
+      "hs",
+      "hsc",
+      "lhs",
+      "ly",
+      "x",
+      "y"
+    ]
 
 -- | This was added in @transformers-0.6.0.0@. See
 -- <https://hub.darcs.net/ross/transformers/issue/49>.

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -74,9 +74,10 @@ extensions :: Map.Map Fields.FieldName (Set.Set String)
 extensions =
   let (=:) :: String -> [String] -> (Fields.FieldName, Set.Set String)
       k =: v = (String.toUtf8 k, Set.fromList v)
+      hs = ["hs", "lhs"]
    in Map.fromList
-        [ "exposed-modules" =: ["hs", "lhs"],
-          "other-modules" =: ["hs", "lhs"]
+        [ "exposed-modules" =: hs,
+          "other-modules" =: hs
         ]
 
 -- | This was added in @transformers-0.6.0.0@. See

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -91,7 +91,9 @@ extensions =
       "gc",
       "hs",
       "hsc",
+      "hsig",
       "lhs",
+      "lhsig",
       "ly",
       "x",
       "y"

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -780,6 +780,48 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
+  Hspec.it "discovers a greencard module" $ do
+    expectDiscover
+      ["M.gc"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a c2hs module" $ do
+    expectDiscover
+      ["M.chs"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a hsc2hs module" $ do
+    expectDiscover
+      ["M.hsc"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a happy (y) module" $ do
+    expectDiscover
+      ["M.y"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a happy (ly) module" $ do
+    expectDiscover
+      ["M.ly"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers an alex module" $ do
+    expectDiscover
+      ["M.x"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a cpphs module" $ do
+    expectDiscover
+      ["M.cpphs"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
   Hspec.it "ignores discover pragma separated by comment" $ do
     expectGilded
       "library\n -- cabal-gild: discover .\n -- foo\n exposed-modules: M"

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -774,7 +774,7 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n    N\n"
 
-  Hspec.it "discovers a literate haskell module" $ do
+  Hspec.it "discovers a literate module" $ do
     expectDiscover
       ["M.lhs"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
@@ -819,6 +819,18 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
   Hspec.it "discovers a cpphs module" $ do
     expectDiscover
       ["M.cpphs"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a signature" $ do
+    expectDiscover
+      ["M.hsig"]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a literate signature" $ do
+    expectDiscover
+      ["M.hsig"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 


### PR DESCRIPTION
This fixes #14. See also #16. 

These are documented by Cabal here: https://cabal.readthedocs.io/en/3.10/cabal-package.html#modules-and-preprocessors

- c2hs: `*.chs`
- cpphs: `*.cpphs`
- GreenCard: `*.gc`
- Haskell: `*.hs` and `*.lhs`
- Backpack: `*.hsig` and `*.lhsig`
- hsc2hs: `*.hsc`
- Happy: `*.ly` and `*.y`
- Alex: `*.x`