### PR TITLE
Allow discovering signatures

### DIFF
--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -68,7 +68,8 @@ relevantFieldNames =
     fmap
       String.toUtf8
       [ "exposed-modules",
-        "other-modules"
+        "other-modules",
+        "signatures"
       ]
 
 -- | Attempts to strip any of the given extensions from the file path. If any

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -774,65 +774,71 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n    N\n"
 
-  Hspec.it "discovers a literate module" $ do
+  Hspec.it "discovers a .lhs file" $ do
     expectDiscover
       ["M.lhs"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a greencard module" $ do
+  Hspec.it "discovers a .gc file" $ do
     expectDiscover
       ["M.gc"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a c2hs module" $ do
+  Hspec.it "discovers a .chs file" $ do
     expectDiscover
       ["M.chs"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a hsc2hs module" $ do
+  Hspec.it "discovers a .hsc file" $ do
     expectDiscover
       ["M.hsc"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a happy (y) module" $ do
+  Hspec.it "discovers a .y file" $ do
     expectDiscover
       ["M.y"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a happy (ly) module" $ do
+  Hspec.it "discovers a .ly file" $ do
     expectDiscover
       ["M.ly"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers an alex module" $ do
+  Hspec.it "discovers a .x file" $ do
     expectDiscover
       ["M.x"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a cpphs module" $ do
+  Hspec.it "discovers a .cpphs file" $ do
     expectDiscover
       ["M.cpphs"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a signature" $ do
+  Hspec.it "discovers a .hsig file" $ do
     expectDiscover
       ["M.hsig"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
-  Hspec.it "discovers a literate signature" $ do
+  Hspec.it "discovers a .lhsig file" $ do
     expectDiscover
-      ["M.hsig"]
+      ["M.lhsig"]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
+
+  Hspec.it "discovers a signature" $ do
+    expectDiscover
+      ["S.hsig"]
+      "library\n -- cabal-gild: discover .\n signatures:"
+      "library\n  -- cabal-gild: discover .\n  signatures: S\n"
 
   Hspec.it "ignores discover pragma separated by comment" $ do
     expectGilded


### PR DESCRIPTION
This PR updates the discover pragma to also support the `signatures` field. This allows you to discover Backpack signatures (`*.hsig` and `*.lhsig`) using `-- cabal-gild: discover DIRECTORY`. For example:

``` cabal
cabal-version: 2.0
name: example
version: 0.2024.2.19

library
  -- cabal-gild: discover src
  signatures: ...
```

This was motivated by the discussion in #17. 