### PR TITLE
Allow discovering within multiple directories

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -161,9 +161,9 @@
           "uses": "actions/checkout@v4"
         },
         {
-          "uses": "haskell-actions/run-ormolu@v14",
+          "uses": "haskell-actions/run-ormolu@v15",
           "with": {
-            "version": "0.7.3.0"
+            "version": "0.7.4.0"
           }
         }
       ]

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ Gild supports special comments in package descriptions that act as pragmas.
 Each pragma starts with `-- cabal-gild:`. Pragmas must be the last comment
 before a field.
 
-- `-- cabal-gild: discover DIRECTORY`: This pragma will discover any Haskell
-  files in the given directory and use those to populate the list of modules.
-  For example, given this input:
+- `-- cabal-gild: discover DIRECTORY [DIRECTORY ...]`: This pragma will
+  discover any Haskell files in any of the given directories and use those to
+  populate the list of modules or signatures. For example, given this input:
 
   ``` cabal
   library
@@ -180,12 +180,13 @@ before a field.
     exposed-modules: M
   ```
 
-  This pragma only works with the `exposed-modules` and `other-modules` fields.
-  It will be ignored on all other fields.
+  This pragma only works with the `exposed-modules`, `other-modules`, and
+  `signatures` fields. It will be ignored on all other fields.
 
-  Any existing modules in the list will be ignored. The entire field will be
-  replaced. This means adding, removing, and renaming modules should be handled
-  automatically.
+  Any existing modules or signatures in the list will be ignored. The entire
+  field (including comments) will be replaced. This means adding, removing, and
+  renaming modules or signatures should be handled automatically.
 
   This pragma searches for files with any of the following extensions: `*.chs`,
-  `*.cpphs`, `*.gc`, `*.hs`, `*.hsc`, `*.lhs`, `*.ly`, `*.x`, or `*.y`,
+  `*.cpphs`, `*.gc`, `*.hs`, `*.hsc`, `*.hsig`, `*.lhs`, `*.lhsig`, `*.ly`,
+  `*.x`, or `*.y`,

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -31,7 +31,7 @@ fields ::
   FilePath ->
   [Fields.Field [Comment.Comment a]] ->
   m [Fields.Field [Comment.Comment a]]
-fields = mapM . field
+fields = traverse . field
 
 -- | Evaluates pragmas within the given field. Or, if the field is a section,
 -- evaluates pragmas recursively within the fields of the section.

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -55,12 +55,10 @@ field p f = case f of
       Pragma.Discover ds -> do
         let root = FilePath.takeDirectory p
             directories =
-              fmap
-                ( FilePath.dropTrailingPathSeparator
-                    . FilePath.normalise
-                    . FilePath.combine root
-                )
-                $ NonEmpty.toList ds
+              FilePath.dropTrailingPathSeparator
+                . FilePath.normalise
+                . FilePath.combine root
+                <$> NonEmpty.toList ds
         files <- Trans.lift . fmap mconcat $ traverse MonadWalk.walk directories
         pure
           . Fields.Field n

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -54,7 +54,13 @@ field p f = case f of
     case pragma of
       Pragma.Discover ds -> do
         let root = FilePath.takeDirectory p
-            directories = fmap (FilePath.combine root) $ NonEmpty.toList ds
+            directories =
+              fmap
+                ( FilePath.dropTrailingPathSeparator
+                    . FilePath.normalise
+                    . FilePath.combine root
+                )
+                $ NonEmpty.toList ds
         files <- Trans.lift . fmap mconcat $ traverse MonadWalk.walk directories
         pure
           . Fields.Field n

--- a/source/library/CabalGild/Class/MonadWalk.hs
+++ b/source/library/CabalGild/Class/MonadWalk.hs
@@ -25,4 +25,4 @@ listDirectoryRecursively d = do
         if b
           then listDirectoryRecursively p
           else pure [p]
-  concat <$> mapM f es
+  mconcat <$> traverse f es

--- a/source/library/CabalGild/Type/Flag.hs
+++ b/source/library/CabalGild/Type/Flag.hs
@@ -4,6 +4,7 @@ import qualified CabalGild.Exception.InvalidOption as InvalidOption
 import qualified CabalGild.Exception.UnexpectedArgument as UnexpectedArgument
 import qualified CabalGild.Exception.UnknownOption as UnknownOption
 import qualified Control.Monad.Catch as Exception
+import qualified Data.Foldable as Foldable
 import qualified System.Console.GetOpt as GetOpt
 
 -- | A flag, which represents a command line option. The values associated with
@@ -69,7 +70,7 @@ options =
 fromArguments :: (Exception.MonadThrow m) => [String] -> m [Flag]
 fromArguments arguments = do
   let (flgs, args, opts, errs) = GetOpt.getOpt' GetOpt.Permute options arguments
-  mapM_ (Exception.throwM . UnexpectedArgument.fromString) args
-  mapM_ (Exception.throwM . InvalidOption.fromString) errs
-  mapM_ (Exception.throwM . UnknownOption.fromString) opts
+  Foldable.traverse_ (Exception.throwM . UnexpectedArgument.fromString) args
+  Foldable.traverse_ (Exception.throwM . InvalidOption.fromString) errs
+  Foldable.traverse_ (Exception.throwM . UnknownOption.fromString) opts
   pure flgs

--- a/source/library/CabalGild/Type/Pragma.hs
+++ b/source/library/CabalGild/Type/Pragma.hs
@@ -1,6 +1,7 @@
 module CabalGild.Type.Pragma where
 
 import qualified Control.Monad as Monad
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Distribution.Compat.CharParsing as CharParsing
 import qualified Distribution.FieldGrammar.Newtypes as Newtypes
 import qualified Distribution.Parsec as Parsec
@@ -8,7 +9,7 @@ import qualified Distribution.Parsec as Parsec
 -- | A pragma, which is a special comment used to customize behavior.
 newtype Pragma
   = -- | Discover modules within the given directory.
-    Discover FilePath
+    Discover (NonEmpty.NonEmpty FilePath)
   deriving (Eq, Show)
 
 instance Parsec.Parsec Pragma where
@@ -18,4 +19,4 @@ instance Parsec.Parsec Pragma where
     CharParsing.spaces
     Monad.void $ CharParsing.string "discover"
     CharParsing.skipSpaces1
-    Discover . Newtypes.getFilePathNT <$> Parsec.parsec
+    Discover . pure . Newtypes.getFilePathNT <$> Parsec.parsec

--- a/source/library/CabalGild/Type/Pragma.hs
+++ b/source/library/CabalGild/Type/Pragma.hs
@@ -19,4 +19,6 @@ instance Parsec.Parsec Pragma where
     CharParsing.spaces
     Monad.void $ CharParsing.string "discover"
     CharParsing.skipSpaces1
-    Discover . pure . Newtypes.getFilePathNT <$> Parsec.parsec
+    Discover
+      . fmap Newtypes.getFilePathNT
+      <$> CharParsing.sepByNonEmpty Parsec.parsec CharParsing.skipSpaces1

--- a/source/library/CabalGild/Type/SomeParsecParser.hs
+++ b/source/library/CabalGild/Type/SomeParsecParser.hs
@@ -17,7 +17,8 @@ import qualified Text.PrettyPrint as PrettyPrint
 -- | This type bundles up a parser and a pretty printer for some type.
 -- Typically they will just be monomorphic versions of 'Parsec.parsec' and
 -- 'Pretty.prettyVersioned'.
-data SomeParsecParser = forall a.
+data SomeParsecParser
+  = forall a.
   SomeParsecParser
   { parsec :: Parsec.ParsecParser a,
     pretty :: CabalSpecVersion.CabalSpecVersion -> a -> PrettyPrint.Doc

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -752,91 +752,91 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
 
   Hspec.it "discovers an exposed module" $ do
     expectDiscover
-      ["M.hs"]
+      [(".", ["M.hs"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers an other module" $ do
     expectDiscover
-      ["M.hs"]
+      [(".", ["M.hs"])]
       "library\n -- cabal-gild: discover .\n other-modules:"
       "library\n  -- cabal-gild: discover .\n  other-modules: M\n"
 
   Hspec.it "discovers a nested module" $ do
     expectDiscover
-      [FilePath.combine "N" "O.hs"]
+      [(".", [FilePath.combine "N" "O.hs"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: N.O\n"
 
   Hspec.it "discovers multiple modules" $ do
     expectDiscover
-      ["M.hs", "N.hs"]
+      [(".", ["M.hs", "N.hs"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n    N\n"
 
   Hspec.it "discovers a .lhs file" $ do
     expectDiscover
-      ["M.lhs"]
+      [(".", ["M.lhs"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .gc file" $ do
     expectDiscover
-      ["M.gc"]
+      [(".", ["M.gc"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .chs file" $ do
     expectDiscover
-      ["M.chs"]
+      [(".", ["M.chs"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .hsc file" $ do
     expectDiscover
-      ["M.hsc"]
+      [(".", ["M.hsc"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .y file" $ do
     expectDiscover
-      ["M.y"]
+      [(".", ["M.y"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .ly file" $ do
     expectDiscover
-      ["M.ly"]
+      [(".", ["M.ly"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .x file" $ do
     expectDiscover
-      ["M.x"]
+      [(".", ["M.x"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .cpphs file" $ do
     expectDiscover
-      ["M.cpphs"]
+      [(".", ["M.cpphs"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .hsig file" $ do
     expectDiscover
-      ["M.hsig"]
+      [(".", ["M.hsig"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a .lhsig file" $ do
     expectDiscover
-      ["M.lhsig"]
+      [(".", ["M.lhsig"])]
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules: M\n"
 
   Hspec.it "discovers a signature" $ do
     expectDiscover
-      ["S.hsig"]
+      [(".", ["S.hsig"])]
       "library\n -- cabal-gild: discover .\n signatures:"
       "library\n  -- cabal-gild: discover .\n  signatures: S\n"
 
@@ -856,29 +856,17 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "-- cabal-gild: unknown\n"
 
   Hspec.it "discovers from multiple directories" $ do
-    let (a, s, w) =
-          runTest
-            (Gild.mainWith "" [])
-            ( Map.singleton Nothing (String.toUtf8 "library\n -- cabal-gild: discover d e\n exposed-modules:"),
-              Map.fromList
-                [ (FilePath.combine "." "d", ["M.hs"]),
-                  (FilePath.combine "." "e", ["N.hs"])
-                ]
-            )
-            Map.empty
-    a `Hspec.shouldBe` Right ()
-    w `Hspec.shouldBe` []
-    actual <- case Map.toList s of
-      [(Nothing, x)] -> pure x
-      _ -> fail $ "impossible: " <> show s
-    actual `Hspec.shouldBe` String.toUtf8 "library\n  -- cabal-gild: discover d e\n  exposed-modules:\n    M\n    N\n"
+    expectDiscover
+      [("d", ["M.hs"]), ("e", ["N.hs"])]
+      "library\n -- cabal-gild: discover d e\n exposed-modules:"
+      "library\n  -- cabal-gild: discover d e\n  exposed-modules:\n    M\n    N\n"
 
 expectGilded :: (Stack.HasCallStack) => String -> String -> Hspec.Expectation
 expectGilded input expected = do
   let (a, s, w) =
         runTest
           (Gild.mainWith "" [])
-          (Map.singleton Nothing (String.toUtf8 input), Map.empty)
+          (Map.singleton Nothing $ String.toUtf8 input, Map.empty)
           Map.empty
   a `Hspec.shouldBe` Right ()
   w `Hspec.shouldBe` []
@@ -903,13 +891,13 @@ expectStable input = do
     _ -> fail $ "impossible: " <> show s
   output `Hspec.shouldBe` input
 
-expectDiscover :: [FilePath] -> String -> String -> Hspec.Expectation
+expectDiscover :: [(FilePath, [FilePath])] -> String -> String -> Hspec.Expectation
 expectDiscover files input expected = do
   let (a, s, w) =
         runTest
           (Gild.mainWith "" [])
-          ( Map.singleton Nothing (String.toUtf8 input),
-            Map.singleton (FilePath.combine "." ".") files
+          ( Map.singleton Nothing $ String.toUtf8 input,
+            Map.fromList $ fmap (\(d, fs) -> (d, FilePath.combine d <$> fs)) files
           )
           Map.empty
   a `Hspec.shouldBe` Right ()

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -855,6 +855,24 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "-- cabal-gild: unknown"
       "-- cabal-gild: unknown\n"
 
+  Hspec.it "discovers from multiple directories" $ do
+    let (a, s, w) =
+          runTest
+            (Gild.mainWith "" [])
+            ( Map.singleton Nothing (String.toUtf8 "library\n -- cabal-gild: discover d e\n exposed-modules:"),
+              Map.fromList
+                [ (FilePath.combine "." "d", ["M.hs"]),
+                  (FilePath.combine "." "e", ["N.hs"])
+                ]
+            )
+            Map.empty
+    a `Hspec.shouldBe` Right ()
+    w `Hspec.shouldBe` []
+    actual <- case Map.toList s of
+      [(Nothing, x)] -> pure x
+      _ -> fail $ "impossible: " <> show s
+    actual `Hspec.shouldBe` String.toUtf8 "library\n  -- cabal-gild: discover d e\n  exposed-modules:\n    M\n    N\n"
+
 expectGilded :: (Stack.HasCallStack) => String -> String -> Hspec.Expectation
 expectGilded input expected = do
   let (a, s, w) =


### PR DESCRIPTION
Fixes #13.

This PR updates the discover pragma to support multiple directories. 

``` cabal
-- before
library
  -- cabal-gild: discover first
  exposed-modules: ...
  -- cabal-gild: discover second
  exposed-modules: ...
```

``` cabal
-- after
library
  -- cabal-gild: discover first second
  exposed-modules: ...
```