### PR TITLE
Strip blank spaces from sections using curly brackets

### DIFF
--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -76,6 +76,7 @@ library
     CabalGild.Action.ReflowText
     CabalGild.Action.RemovePositions
     CabalGild.Action.Render
+    CabalGild.Action.StripBlanks
     CabalGild.Class.MonadLog
     CabalGild.Class.MonadRead
     CabalGild.Class.MonadWalk

--- a/source/library/CabalGild/Action/AttachComments.hs
+++ b/source/library/CabalGild/Action/AttachComments.hs
@@ -4,26 +4,19 @@ import qualified CabalGild.Type.Comment as Comment
 import qualified Control.Monad.Trans.State as StateT
 import qualified Distribution.Fields as Fields
 
--- | High level wrapper around 'fields' that makes this action easier to
--- compose with other actions.
+-- | High level wrapper around 'field' that makes this action easier to compose
+-- with other actions.
 run ::
   (Applicative m, Ord p) =>
   ([Fields.Field p], [Comment.Comment p]) ->
   m ([Fields.Field (p, [Comment.Comment p])], [Comment.Comment p])
-run (fs, cs) = pure $ StateT.runState (fields fs) cs
+run (fs, cs) = pure $ StateT.runState (traverse field fs) cs
 
--- | Given a bunch of fields and comments, attaches each comment to the field
--- that it belongs to. It is assumed that both the fields and comments are
--- already sorted by their position @p@. This precondition is not checked.
-fields ::
-  (Ord p) =>
-  [Fields.Field p] ->
-  StateT.State [Comment.Comment p] [Fields.Field (p, [Comment.Comment p])]
-fields = traverse field
-
--- | Attaches comments to a single field. Note that comments actually end up
--- attached to the field's name. That's because the 'Field.Field' type doesn't
--- have any annotations directly on it.
+-- | Attaches comments to a single field. It is assumed that both the fields
+-- and comments are already sorted by their position @p@. This precondition is
+-- not checked. Note that comments actually end up attached to the field's
+-- name. That's because the 'Field.Field' type doesn't have any annotations
+-- directly on it.
 field ::
   (Ord p) =>
   Fields.Field p ->

--- a/source/library/CabalGild/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Action/EvaluatePragmas.hs
@@ -18,22 +18,14 @@ import qualified Distribution.Parsec as Parsec
 import qualified Distribution.Utils.Generic as Utils
 import qualified System.FilePath as FilePath
 
--- | High level wrapper around 'fields' that makes this action easier to
--- compose with other actions.
+-- | High level wrapper around 'field' that makes this action easier to compose
+-- with other actions.
 run ::
   (MonadWalk.MonadWalk m) =>
   FilePath ->
   ([Fields.Field [Comment.Comment a]], cs) ->
   m ([Fields.Field [Comment.Comment a]], cs)
-run p (fs, cs) = (,) <$> fields p fs <*> pure cs
-
--- | Evaluates pragmas modules within the given fields.
-fields ::
-  (MonadWalk.MonadWalk m) =>
-  FilePath ->
-  [Fields.Field [Comment.Comment a]] ->
-  m [Fields.Field [Comment.Comment a]]
-fields = traverse . field
+run p (fs, cs) = (,) <$> traverse (field p) fs <*> pure cs
 
 -- | Evaluates pragmas within the given field. Or, if the field is a section,
 -- evaluates pragmas recursively within the fields of the section.
@@ -65,7 +57,7 @@ field p f = case f of
           . fmap (ModuleName.toFieldLine [])
           . Maybe.mapMaybe (toModuleName directories)
           $ Maybe.mapMaybe (stripAnyExtension extensions) files
-  Fields.Section n sas fs -> Fields.Section n sas <$> fields p fs
+  Fields.Section n sas fs -> Fields.Section n sas <$> traverse (field p) fs
 
 -- | These are the names of the fields that can have this action applied to
 -- them.

--- a/source/library/CabalGild/Action/FormatFields.hs
+++ b/source/library/CabalGild/Action/FormatFields.hs
@@ -24,21 +24,13 @@ import qualified Distribution.Types.PkgconfigDependency as PkgconfigDependency
 import qualified Language.Haskell.Extension as Extension
 import qualified Text.PrettyPrint as PrettyPrint
 
--- | A wrapper around 'fields' to allow this to be composed with other actions.
+-- | A wrapper around 'field' to allow this to be composed with other actions.
 run ::
   (Applicative m, Monoid cs) =>
   CabalSpecVersion.CabalSpecVersion ->
   ([Fields.Field cs], cs) ->
   m ([Fields.Field cs], cs)
-run csv (fs, cs) = pure (fields csv fs, cs)
-
--- | A wrapper around 'field'.
-fields ::
-  (Monoid cs) =>
-  CabalSpecVersion.CabalSpecVersion ->
-  [Fields.Field cs] ->
-  [Fields.Field cs]
-fields = fmap . field
+run csv (fs, cs) = pure (fmap (field csv) fs, cs)
 
 -- | Formats the given field, if applicable. Otherwise returns the field as is.
 -- If the field is a section, the fields within the section will be recursively
@@ -52,7 +44,7 @@ field csv f = case f of
   Fields.Field n fls -> case Map.lookup (Name.value n) parsers of
     Nothing -> f
     Just spp -> Fields.Field n $ fieldLines csv fls spp
-  Fields.Section n sas fs -> Fields.Section n sas $ fields csv fs
+  Fields.Section n sas fs -> Fields.Section n sas $ fmap (field csv) fs
 
 -- | Attempts to parse the given field lines using the given parser. If parsing
 -- fails, the field lines will be returned as is. Comments within the field

--- a/source/library/CabalGild/Action/RemovePositions.hs
+++ b/source/library/CabalGild/Action/RemovePositions.hs
@@ -3,20 +3,12 @@ module CabalGild.Action.RemovePositions where
 import qualified CabalGild.Type.Comment as Comment
 import qualified Distribution.Fields as Fields
 
--- | A wrapper around 'fields' to allow this to be composed with other actions.
+-- | A wrapper around 'field' to allow this to be composed with other actions.
 run ::
   (Applicative m) =>
   ([Fields.Field (p, [Comment.Comment p])], [Comment.Comment p]) ->
   m ([Fields.Field [Comment.Comment ()]], [Comment.Comment ()])
-run (fs, cs) = pure (fields fs, comments cs)
-
--- | Removes the positions from some fields and their comments. This is useful
--- for two reasons: the annotations become simpler, and it's clear that the
--- positions won't be used for anything else.
-fields ::
-  [Fields.Field (p, [Comment.Comment p])] ->
-  [Fields.Field [Comment.Comment ()]]
-fields = fmap field
+run (fs, cs) = pure (fmap field fs, comments cs)
 
 -- | Removes the positions from a field and its comments.
 field ::
@@ -24,7 +16,7 @@ field ::
   Fields.Field [Comment.Comment ()]
 field f = case f of
   Fields.Field n fls -> Fields.Field (name n) $ fieldLines fls
-  Fields.Section n sas fs -> Fields.Section (name n) (sectionArgs sas) $ fields fs
+  Fields.Section n sas fs -> Fields.Section (name n) (sectionArgs sas) $ fmap field fs
 
 -- | Removes the positions from a name and its comments.
 name ::

--- a/source/library/CabalGild/Action/StripBlanks.hs
+++ b/source/library/CabalGild/Action/StripBlanks.hs
@@ -1,0 +1,41 @@
+module CabalGild.Action.StripBlanks where
+
+import qualified Data.ByteString.Char8 as Latin1
+import qualified Distribution.Fields as Fields
+
+-- | High level wrapper around 'field' that makes this action easier to compose
+-- with other actions.
+run ::
+  (Applicative m) =>
+  ([Fields.Field a], cs) ->
+  m ([Fields.Field a], cs)
+run (fs, cs) = pure (fmap field fs, cs)
+
+-- | Strips blank space from the field recursively. In practice there should
+-- not be any leading or trailing blank space to begin with. However the legacy
+-- curly bracket syntax can introduce trailing blank space. For example with
+-- @s { f : x }@ the field value will have a trailing space (@"x "@).
+field :: Fields.Field a -> Fields.Field a
+field f = case f of
+  Fields.Field n fls ->
+    Fields.Field (name n) (fmap fieldLine fls)
+  Fields.Section n sas fs ->
+    Fields.Section (name n) (fmap sectionArg sas) (fmap field fs)
+
+-- | Strips blank space from the field's name.
+name :: Fields.Name a -> Fields.Name a
+name (Fields.Name a bs) = Fields.Name a (Latin1.strip bs)
+
+-- | Strips blank space from the field line.
+fieldLine :: Fields.FieldLine a -> Fields.FieldLine a
+fieldLine (Fields.FieldLine a bs) = Fields.FieldLine a (Latin1.strip bs)
+
+-- | Strips blank space from the section argument.
+sectionArg :: Fields.SectionArg a -> Fields.SectionArg a
+sectionArg sa = case sa of
+  Fields.SecArgName a bs ->
+    Fields.SecArgName a (Latin1.strip bs)
+  Fields.SecArgStr a bs ->
+    Fields.SecArgStr a (Latin1.strip bs)
+  Fields.SecArgOther a bs ->
+    Fields.SecArgOther a (Latin1.strip bs)

--- a/source/library/CabalGild/Main.hs
+++ b/source/library/CabalGild/Main.hs
@@ -9,6 +9,7 @@ import qualified CabalGild.Action.GetCabalVersion as GetCabalVersion
 import qualified CabalGild.Action.ReflowText as ReflowText
 import qualified CabalGild.Action.RemovePositions as RemovePositions
 import qualified CabalGild.Action.Render as Render
+import qualified CabalGild.Action.StripBlanks as StripBlanks
 import qualified CabalGild.Class.MonadLog as MonadLog
 import qualified CabalGild.Class.MonadRead as MonadRead
 import qualified CabalGild.Class.MonadWalk as MonadWalk
@@ -90,7 +91,8 @@ mainWith name arguments = do
   let csv = GetCabalVersion.fromFields fields
       comments = ExtractComments.fromByteString input
   output <-
-    ( AttachComments.run
+    ( StripBlanks.run
+        Monad.>=> AttachComments.run
         Monad.>=> ReflowText.run csv
         Monad.>=> RemovePositions.run
         Monad.>=> EvaluatePragmas.run (Maybe.fromMaybe (Config.stdin config) $ Config.input config)

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -861,6 +861,26 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover d e\n exposed-modules:"
       "library\n  -- cabal-gild: discover d e\n  exposed-modules:\n    M\n    N\n"
 
+  Hspec.it "parses an empty curly bracket section" $ do
+    expectGilded
+      "s{}"
+      "s\n"
+
+  Hspec.it "parses a curly bracket section with a field" $ do
+    expectGilded
+      "s{f:x}"
+      "s\n  f: x\n"
+
+  Hspec.it "strips blanks from a field in a curly bracket section" $ do
+    expectGilded
+      "s { f : x } "
+      "s\n  f: x\n"
+
+  Hspec.it "parses a nested curly bracket section" $ do
+    expectGilded
+      "s{t{}}"
+      "s\n  t\n"
+
 expectGilded :: (Stack.HasCallStack) => String -> String -> Hspec.Expectation
 expectGilded input expected = do
   let (a, s, w) =

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -861,22 +861,37 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover d e\n exposed-modules:"
       "library\n  -- cabal-gild: discover d e\n  exposed-modules:\n    M\n    N\n"
 
-  Hspec.it "parses an empty curly bracket section" $ do
+  Hspec.it "parses an empty brace section" $ do
     expectGilded
       "s{}"
       "s\n"
 
-  Hspec.it "parses a curly bracket section with a field" $ do
+  Hspec.it "parses a brace section with a layout field" $ do
     expectGilded
       "s{f:x}"
       "s\n  f: x\n"
 
-  Hspec.it "strips blanks from a field in a curly bracket section" $ do
+  Hspec.it "parses a brace section with a brace field" $ do
+    expectGilded
+      "s{f:{x}}"
+      "s\n  f: x\n"
+
+  Hspec.it "strips blanks from a layout field in a brace section" $ do
     expectGilded
       "s { f : x } "
       "s\n  f: x\n"
 
-  Hspec.it "parses a nested curly bracket section" $ do
+  Hspec.it "strips blanks from a brace field in a brace section" $ do
+    expectGilded
+      "s { f : { x } } "
+      "s\n  f: x\n"
+
+  Hspec.it "parses a brace section with multiple fields" $ do
+    expectGilded
+      "s { f : { x } g : { y } } "
+      "s\n  f: x\n  g: y\n"
+
+  Hspec.it "parses a nested brace section" $ do
     expectGilded
       "s{t{}}"
       "s\n  t\n"


### PR DESCRIPTION
It's possible to define a section using braces (curly brackets) rather than layout (indentation). For example:

``` cabal
library { default-language: Haskell2010 }
```

These are discouraged, but allowable as input. Explicit support for this is nice because other tools could emit package descriptions using braces and then use Gild to turn it into the normal layout format. 

This pull request started by adding tests for sections like this, then noticing that extra spaces snuck in. So I figured I might as well strip the extra blank spaces since generally there should be no trailing space in the output.