### PR TITLE
Fix release binaries

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,6 +63,10 @@
           "run": "cp $( cabal list-bin cabal-gild ) artifact"
         },
         {
+          "if": "matrix.platform == 'macos'",
+          "run": "codesign --sign - artifact/cabal-gild"
+        },
+        {
           "run": "tar -cvf artifact.tar artifact"
         },
         {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -67,9 +67,6 @@
           "run": "codesign --sign - artifact/cabal-gild"
         },
         {
-          "run": "tar -cvf artifact.tar artifact"
-        },
-        {
           "uses": "actions/upload-artifact@v4",
           "with": {
             "name": "cabal-gild-${{ github.sha }}-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.ghc }}",
@@ -166,6 +163,19 @@
           "with": {
             "version": "0.7.4.0"
           }
+        }
+      ]
+    },
+    "release-todo": {
+      "name": "Release TODO",
+      "needs": "build",
+      "runs-on": "ubuntu-22.04",
+      "steps": [
+        {
+          "uses": "actions/download-artifact@v4"
+        },
+        {
+          "run": "ls -l"
         }
       ]
     },

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -166,11 +166,12 @@
         }
       ]
     },
-    "release-todo": {
+    "release": {
       "env": {
         "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
       },
-      "name": "Release TODO",
+      "if": "github.event_name == 'release'",
+      "name": "Release",
       "needs": "build",
       "runs-on": "ubuntu-22.04",
       "steps": [
@@ -178,100 +179,32 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tgz cabal-gild",
+          "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8.1/${{ env.PREFIX }}.tar.gz ."
+        },
+        {
+          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tar.gz cabal-gild",
           "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8.1"
         },
         {
-          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-arm64.tgz cabal-gild",
+          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-arm64.tar.gz cabal-gild",
           "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8.1"
         },
         {
-          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-linux-x64.tgz cabal-gild",
+          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-linux-x64.tar.gz cabal-gild",
           "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8.1"
         },
         {
-          "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-windows-x64.tgz cabal-gild.exe",
+          "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-windows-x64.tar.gz cabal-gild.exe",
           "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8.1"
         },
         {
-          "uses": "actions/upload-artifact@v4",
+          "uses": "softprops/action-gh-release@v1",
           "with": {
-            "path": "${{ env.PREFIX }}-*-*.tgz"
-          }
-        }
-      ]
-    },
-    "release": {
-      "if": "github.event_name == 'release'",
-      "name": "Release",
-      "needs": "build",
-      "runs-on": "ubuntu-22.04",
-      "steps": [
-        {
-          "uses": "actions/download-artifact@v4",
-          "with": {
-            "name": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8.1",
-            "path": "artifact-ubuntu-22.04"
+            "files": "${{ env.PREFIX }}*.tar.gz"
           }
         },
         {
-          "uses": "svenstaro/upload-release-action@v2",
-          "with": {
-            "asset_name": "cabal-gild-${{ github.event.release.tag_name }}.tar.gz",
-            "file": "artifact-ubuntu-22.04/cabal-gild-${{ github.event.release.tag_name }}.tar.gz"
-          }
-        },
-        {
-          "uses": "svenstaro/upload-release-action@v2",
-          "with": {
-            "asset_name": "cabal-gild-${{ github.event.release.tag_name }}-linux-x64",
-            "file": "artifact-ubuntu-22.04/cabal-gild"
-          }
-        },
-        {
-          "uses": "actions/download-artifact@v4",
-          "with": {
-            "name": "cabal-gild-${{ github.sha }}-macos-13-9.8.1",
-            "path": "artifact-macos-13"
-          }
-        },
-        {
-          "uses": "svenstaro/upload-release-action@v2",
-          "with": {
-            "asset_name": "cabal-gild-${{ github.event.release.tag_name }}-darwin-x64",
-            "file": "artifact-macos-13/cabal-gild"
-          }
-        },
-        {
-          "uses": "actions/download-artifact@v4",
-          "with": {
-            "name": "cabal-gild-${{ github.sha }}-macos-14-9.8.1",
-            "path": "artifact-macos-14"
-          }
-        },
-        {
-          "uses": "svenstaro/upload-release-action@v2",
-          "with": {
-            "asset_name": "cabal-gild-${{ github.event.release.tag_name }}-darwin-arm64",
-            "file": "artifact-macos-14/cabal-gild"
-          }
-        },
-        {
-          "uses": "actions/download-artifact@v4",
-          "with": {
-            "name": "cabal-gild-${{ github.sha }}-windows-2022-9.8.1",
-            "path": "artifact-windows-2022"
-          }
-        },
-        {
-          "uses": "svenstaro/upload-release-action@v2",
-          "with": {
-            "asset_name": "cabal-gild-${{ github.event.release.tag_name }}-win32-x64.exe",
-            "file": "artifact-windows-2022/cabal-gild.exe"
-          }
-        },
-        {
-          "run": "cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' artifact-ubuntu-22.04/cabal-gild-${{ github.event.release.tag_name }}.tar.gz"
+          "run": "cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' ${{ env.PREFIX }}.tar.gz"
         }
       ]
     }

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,12 +63,6 @@
           "run": "cp $( cabal list-bin cabal-gild ) artifact"
         },
         {
-          "uses": "svenstaro/upx-action@v2",
-          "with": {
-            "files": "artifact/cabal-gild${{ matrix.extension }}"
-          }
-        },
-        {
           "uses": "actions/upload-artifact@v4",
           "with": {
             "name": "cabal-gild-${{ github.sha }}-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.ghc }}",

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -178,19 +178,25 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "chmod -v -v +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tgz --verbose cabal-gild",
+          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tgz cabal-gild",
           "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8.1"
         },
         {
-          "run": "ls -l"
+          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-arm64.tgz cabal-gild",
+          "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8.1"
         },
         {
-          "run": "ls -l cabal-gild-${{ github.sha }}-macos-13-9.8.1"
+          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-linux-x64.tgz cabal-gild",
+          "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8.1"
+        },
+        {
+          "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-windows-x64.tgz cabal-gild.exe",
+          "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8.1"
         },
         {
           "uses": "actions/upload-artifact@v4",
           "with": {
-            "path": "${{ env.PREFIX }}-darwin-x64.tar.gz"
+            "path": "${{ env.PREFIX }}-*-*.tgz"
           }
         }
       ]

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -167,6 +167,9 @@
       ]
     },
     "release-todo": {
+      "env": {
+        "GILD": "cabal-gild-${{ github.event.release.tag_name }}"
+      },
       "name": "Release TODO",
       "needs": "build",
       "runs-on": "ubuntu-22.04",
@@ -175,7 +178,25 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "ls -l"
+          "run": "mkdir $GILD-darwin-x64"
+        },
+        {
+          "run": "mv cabal-gild-${{ github.sha }}-macos-13-9.8.1/cabal-gild $GILD-darwin-x64"
+        },
+        {
+          "run": "chmod +x $GILD-darwin-x64/cabal-gild"
+        },
+        {
+          "run": "tar -cvf $GILD-darwin-x64.tar $GILD-darwin-x64"
+        },
+        {
+          "run": "gzip $GILD-darwin-x64.tar"
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "path": "$GILD-darwin-x64.tar.gz"
+          }
         }
       ]
     },

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -178,24 +178,13 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "mkdir $GILD-darwin-x64"
-        },
-        {
-          "run": "mv cabal-gild-${{ github.sha }}-macos-13-9.8.1/cabal-gild $GILD-darwin-x64"
-        },
-        {
-          "run": "chmod +x $GILD-darwin-x64/cabal-gild"
-        },
-        {
-          "run": "tar -cvf $GILD-darwin-x64.tar $GILD-darwin-x64"
-        },
-        {
-          "run": "gzip $GILD-darwin-x64.tar"
+          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../$GILD-darwin-x64.tgz cabal-gild",
+          "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8.1"
         },
         {
           "uses": "actions/upload-artifact@v4",
           "with": {
-            "path": "$GILD-darwin-x64.tar.gz"
+            "path": "${{ env.GILD }}-darwin-x64.tar.gz"
           }
         }
       ]

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -73,7 +73,7 @@
           "run": "cabal run -- cabal-gild-test-suite --randomize --strict"
         },
         {
-          "run": "cabal run -- cabal-gild --input cabal-gild.cabal --mode check"
+          "run": "artifact/cabal-gild --input cabal-gild.cabal --mode check"
         }
       ],
       "strategy": {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,6 +63,9 @@
           "run": "cp $( cabal list-bin cabal-gild ) artifact"
         },
         {
+          "run": "tar -cvf artifact.tar artifact"
+        },
+        {
           "uses": "actions/upload-artifact@v4",
           "with": {
             "name": "cabal-gild-${{ github.sha }}-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.ghc }}",

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -168,7 +168,7 @@
     },
     "release-todo": {
       "env": {
-        "GILD": "cabal-gild-${{ github.event.release.tag_name }}"
+        "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
       },
       "name": "Release TODO",
       "needs": "build",
@@ -178,13 +178,19 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../$GILD-darwin-x64.tgz cabal-gild",
+          "run": "chmod -v -v +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tgz --verbose cabal-gild",
           "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8.1"
+        },
+        {
+          "run": "ls -l"
+        },
+        {
+          "run": "ls -l cabal-gild-${{ github.sha }}-macos-13-9.8.1"
         },
         {
           "uses": "actions/upload-artifact@v4",
           "with": {
-            "path": "${{ env.GILD }}-darwin-x64.tar.gz"
+            "path": "${{ env.PREFIX }}-darwin-x64.tar.gz"
           }
         }
       ]


### PR DESCRIPTION
Fixes #24. 

This PR does a few things:

- Package binaries inside `*.tar.gz` files on all platforms. This allows them to retain their executable permissions, but it requires users to decompress and unpack the archives. Each archive contains a single file: `cabal-gild` (`cabal-gild.exe` for Windows). 
- Sign macOS binaries with ad-hoc signatures. 
- Stop using UPX. Binaries are no longer compressed.
- Switches from svenstaro/upload-release-action to softprops/action-gh-release. 