### PR TITLE
Sort extensions by name

### DIFF
--- a/source/library/CabalGild/Type/Extension.hs
+++ b/source/library/CabalGild/Type/Extension.hs
@@ -1,6 +1,5 @@
 module CabalGild.Type.Extension where
 
-import qualified Data.Char as Char
 import qualified Data.Ord as Ord
 import qualified Distribution.Parsec as Parsec
 import qualified Distribution.Pretty as Pretty
@@ -8,29 +7,17 @@ import qualified Language.Haskell.Extension as Extension
 
 -- | This type exists to provide a different 'Ord' instance for
 -- 'Extension.Extension'. The instance provided by @Cabal-syntax@ sorts things
--- in a surprising order. This one sorts things alphabetically with "enable"
--- extensions before "disable" ones.
+-- in a surprising order. This one sorts things alphabetically.
 newtype Extension = Extension
   { unwrap :: Extension.Extension
   }
   deriving (Eq, Show)
 
 instance Ord Extension where
-  compare = Ord.comparing $ \e -> (isDisable $ unwrap e, Pretty.prettyShow e)
+  compare = Ord.comparing Pretty.prettyShow
 
 instance Parsec.Parsec Extension where
   parsec = Extension <$> Parsec.parsec
 
 instance Pretty.Pretty Extension where
   pretty = Pretty.pretty . unwrap
-
--- | Returns 'True' if the given extension is either a
--- 'Extension.DisableExtension' or it's an 'Extension.UnknownExtension' that
--- starts with @"No"@ followed by an uppercase letter.
-isDisable :: Extension.Extension -> Bool
-isDisable e = case e of
-  Extension.EnableExtension _ -> False
-  Extension.DisableExtension _ -> True
-  Extension.UnknownExtension s -> case s of
-    'N' : 'o' : c : _ -> Char.isUpper c
-    _ -> False

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -568,10 +568,10 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n default-extensions: DerivingVia BlockArguments"
       "library\n  default-extensions:\n    BlockArguments\n    DerivingVia\n"
 
-  Hspec.it "sorts disabling extensions after enabling ones" $ do
+  Hspec.it "does not sort disabling extensions after enabling ones" $ do
     expectGilded
-      "library\n default-extensions: NoStrictData StrictData"
-      "library\n  default-extensions:\n    StrictData\n    NoStrictData\n"
+      "library\n default-extensions: StrictData NoStrictData"
+      "library\n  default-extensions:\n    NoStrictData\n    StrictData\n"
 
   Hspec.it "sorts unknown extensions with known ones" $ do
     expectGilded
@@ -586,7 +586,7 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
   Hspec.it "sorts extensions (issue 29)" $ do
     expectGilded
       "library\n default-extensions: Arrows Imaginary1 NoCPP NoImaginary2 NoUnboxedTuples UnicodeSyntax"
-      "library\n  default-extensions:\n    Arrows\n    Imaginary1\n    UnicodeSyntax\n    NoCPP\n    NoImaginary2\n    NoUnboxedTuples\n"
+      "library\n  default-extensions:\n    Arrows\n    Imaginary1\n    NoCPP\n    NoImaginary2\n    NoUnboxedTuples\n    UnicodeSyntax\n"
 
   Hspec.it "sorts other-extensions" $ do
     expectGilded


### PR DESCRIPTION
Fixes #31. Revisits #30 which was a fix for #29. 

This PR changes Gild to simply sort extensions by name. Previously Gild would sort `No*` extensions after others. If you need this behavior, use multiple `default-extensions` fields like this:

``` cabal
-- before
default-extensions:
  ScopedTypeVariables
  NoExplicitForAll
```

``` cabal
-- after
default-extensions: ScopedTypeVariables
default-extensions: NoExplicitForAll
```