### PR TITLE
Retain comments when discovering modules

### DIFF
--- a/source/library/CabalGild/Extra/Name.hs
+++ b/source/library/CabalGild/Extra/Name.hs
@@ -1,10 +1,15 @@
 module CabalGild.Extra.Name where
 
+import qualified Distribution.Compat.Lens as Lens
 import qualified Distribution.Fields as Fields
 
 -- | Extracts the annotation from the given 'Fields.Name'.
 annotation :: Fields.Name a -> a
 annotation (Fields.Name x _) = x
+
+-- | A lens for the 'annotation'.
+annotationLens :: Lens.Lens' (Fields.Name a) a
+annotationLens f s = fmap (\a -> Fields.Name a $ value s) . f $ annotation s
 
 -- | Extracts the value from the given 'Fields.Name'.
 value :: Fields.Name a -> Fields.FieldName

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -799,6 +799,12 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover .\n exposed-modules:"
       "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n    N\n"
 
+  Hspec.it "discovers no modules" $ do
+    expectDiscover
+      [(".", [])]
+      "library\n -- cabal-gild: discover .\n exposed-modules:"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules:\n"
+
   Hspec.it "discovers a .lhs file" $ do
     expectDiscover
       [(".", ["M.lhs"])]
@@ -885,6 +891,24 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       [("d", ["M.hs"]), ("e", ["N.hs"])]
       "library\n -- cabal-gild: discover d e\n exposed-modules:"
       "library\n  -- cabal-gild: discover d e\n  exposed-modules:\n    M\n    N\n"
+
+  Hspec.it "retains comments when discovering" $ do
+    expectDiscover
+      [(".", ["M.hs"])]
+      "library\n -- cabal-gild: discover .\n exposed-modules:\n  -- c\n  N"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    -- c\n    M\n"
+
+  Hspec.it "concatenates comments when discovering" $ do
+    expectDiscover
+      [(".", ["M.hs"])]
+      "library\n -- cabal-gild: discover .\n exposed-modules:\n  -- c\n  N\n  -- d\n  O"
+      "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    -- c\n    -- d\n    M\n"
+
+  Hspec.it "retains comments even when no modules are discovered" $ do
+    expectDiscover
+      [(".", [])]
+      "library\n -- cabal-gild: discover .\n exposed-modules:\n  -- c\n  N"
+      "library\n  -- c\n  -- cabal-gild: discover .\n  exposed-modules:\n"
 
   Hspec.it "parses an empty brace section" $ do
     expectGilded


### PR DESCRIPTION
I discovered this bug while looking at #28. I'm not sure why I didn't make it work this way to begin with. It makes a lot more sense to keep the comments rather than simply drop them. 

The only kind of weird this is that if the input has comments but Gild doesn't discover any modules, the comments will move to above the field. For example:

``` cabal
-- input

-- cabal-gild: discover empty-directory
exposed-modules:
  -- A comment.
  SomeModule
```

``` cabal
-- output

-- A comment.
-- cabal-gild: discover empty-directory
exposed-modules:
```

This happens because there's no field line in the `exposed-modules` to attach a comment to. So I attach the comment to the field itself. Note that the comment will go _above_ any existing comments on the field. This is to keep the pragma as the last comment. 

This is not a scenario I expect many users to find themselves in. 