### PR TITLE
Add warnings for invalid configurations

### DIFF
--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -115,6 +115,7 @@ library
     CabalGild.Type.PkgconfigVersionRange
     CabalGild.Type.Pragma
     CabalGild.Type.Set
+    CabalGild.Type.Severity
     CabalGild.Type.SomeParsecParser
     CabalGild.Type.TestedWith
     CabalGild.Type.VersionRange

--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -111,6 +111,7 @@ library
     CabalGild.Type.List
     CabalGild.Type.Mode
     CabalGild.Type.ModuleReexport
+    CabalGild.Type.Optional
     CabalGild.Type.PkgconfigDependency
     CabalGild.Type.PkgconfigVersionRange
     CabalGild.Type.Pragma

--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -105,6 +105,7 @@ library
     CabalGild.Type.Extension
     CabalGild.Type.Flag
     CabalGild.Type.ForeignLibOption
+    CabalGild.Type.Input
     CabalGild.Type.Language
     CabalGild.Type.LegacyExeDependency
     CabalGild.Type.Line

--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -113,6 +113,7 @@ library
     CabalGild.Type.Mode
     CabalGild.Type.ModuleReexport
     CabalGild.Type.Optional
+    CabalGild.Type.Output
     CabalGild.Type.PkgconfigDependency
     CabalGild.Type.PkgconfigVersionRange
     CabalGild.Type.Pragma

--- a/source/library/CabalGild/Class/MonadLog.hs
+++ b/source/library/CabalGild/Class/MonadLog.hs
@@ -2,13 +2,9 @@ module CabalGild.Class.MonadLog where
 
 -- | A 'Monad' that can also log messages.
 class (Monad m) => MonadLog m where
-  -- | Logs the given message. Typical usage should prefer 'logLn'.
-  log :: String -> m ()
+  -- | Logs the given message followed by a newline.
+  logLn :: String -> m ()
 
--- | Uses 'putStr'.
+-- | Uses 'putStrLn'.
 instance MonadLog IO where
-  log = putStr
-
--- | Logs the message followed by a newline.
-logLn :: (MonadLog m) => String -> m ()
-logLn = CabalGild.Class.MonadLog.log . (<> "\n")
+  logLn = putStrLn

--- a/source/library/CabalGild/Class/MonadLog.hs
+++ b/source/library/CabalGild/Class/MonadLog.hs
@@ -8,3 +8,7 @@ class (Monad m) => MonadLog m where
 -- | Uses 'putStrLn'.
 instance MonadLog IO where
   logLn = putStrLn
+
+-- | Alias for 'logLn'.
+info :: (MonadLog m) => String -> m ()
+info = logLn

--- a/source/library/CabalGild/Class/MonadLog.hs
+++ b/source/library/CabalGild/Class/MonadLog.hs
@@ -1,14 +1,16 @@
 module CabalGild.Class.MonadLog where
 
+import qualified CabalGild.Type.Severity as Severity
+
 -- | A 'Monad' that can also log messages.
 class (Monad m) => MonadLog m where
-  -- | Logs the given message followed by a newline.
-  logLn :: String -> m ()
+  -- | Logs the given message followed by a newline at the given severity.
+  logLn :: Severity.Severity -> String -> m ()
 
 -- | Uses 'putStrLn'.
 instance MonadLog IO where
-  logLn = putStrLn
+  logLn = const putStrLn
 
--- | Alias for 'logLn'.
+-- | Shortcut for 'logLn' at 'Severity.Info'.
 info :: (MonadLog m) => String -> m ()
-info = logLn
+info = logLn Severity.Info

--- a/source/library/CabalGild/Class/MonadLog.hs
+++ b/source/library/CabalGild/Class/MonadLog.hs
@@ -1,6 +1,7 @@
 module CabalGild.Class.MonadLog where
 
 import qualified CabalGild.Type.Severity as Severity
+import qualified System.IO as IO
 
 -- | A 'Monad' that can also log messages.
 class (Monad m) => MonadLog m where
@@ -9,8 +10,14 @@ class (Monad m) => MonadLog m where
 
 -- | Uses 'putStrLn'.
 instance MonadLog IO where
-  logLn = const putStrLn
+  logLn sev = case sev of
+    Severity.Info -> putStrLn
+    Severity.Warn -> IO.hPutStrLn IO.stderr
 
 -- | Shortcut for 'logLn' at 'Severity.Info'.
 info :: (MonadLog m) => String -> m ()
 info = logLn Severity.Info
+
+-- | Shortcut for 'logLn' at 'Severity.Warn'.
+warn :: (MonadLog m) => String -> m ()
+warn = logLn Severity.Warn

--- a/source/library/CabalGild/Class/MonadRead.hs
+++ b/source/library/CabalGild/Class/MonadRead.hs
@@ -1,14 +1,16 @@
 module CabalGild.Class.MonadRead where
 
+import qualified CabalGild.Type.Input as Input
 import qualified Data.ByteString as ByteString
 
 -- | A 'Monad' that can also read input, either from standard input (STDIN) or
 -- from a file.
 class (Monad m) => MonadRead m where
-  -- | Reads input from the given file, or from STDIN if the given file is
-  -- 'Nothing'.
-  read :: Maybe FilePath -> m ByteString.ByteString
+  -- | Reads input from the given 'Input.Input'.
+  read :: Input.Input -> m ByteString.ByteString
 
 -- | Uses 'ByteString.getContents' or 'ByteString.readFile'.
 instance MonadRead IO where
-  read = maybe ByteString.getContents ByteString.readFile
+  read i = case i of
+    Input.Stdin -> ByteString.getContents
+    Input.File f -> ByteString.readFile f

--- a/source/library/CabalGild/Class/MonadWrite.hs
+++ b/source/library/CabalGild/Class/MonadWrite.hs
@@ -1,14 +1,16 @@
 module CabalGild.Class.MonadWrite where
 
+import qualified CabalGild.Type.Output as Output
 import qualified Data.ByteString as ByteString
 
 -- | A 'Monad' that can also write output, either to standard output (STDOUT)
 -- or to a file.
 class (Monad m) => MonadWrite m where
-  -- | Writes output to the given file, or to STDOUT if the given file is
-  -- 'Nothing'.
-  write :: Maybe FilePath -> ByteString.ByteString -> m ()
+  -- | Writes output to the given 'Output.Output'.
+  write :: Output.Output -> ByteString.ByteString -> m ()
 
 -- | Uses 'ByteString.putStr' or 'ByteString.writeFile'.
 instance MonadWrite IO where
-  write = maybe ByteString.putStr ByteString.writeFile
+  write o = case o of
+    Output.Stdout -> ByteString.putStr
+    Output.File f -> ByteString.writeFile f

--- a/source/library/CabalGild/Main.hs
+++ b/source/library/CabalGild/Main.hs
@@ -23,6 +23,8 @@ import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as Latin1
+import qualified Data.Char as Char
+import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 import qualified Data.Version as Version
 import qualified Distribution.Fields as Fields
@@ -77,7 +79,9 @@ mainWith name arguments = do
               "",
               "<https://github.com/tfausak/cabal-gild>"
             ]
-    MonadLog.log $ GetOpt.usageInfo header Flag.options
+    MonadLog.logLn
+      . List.dropWhileEnd Char.isSpace
+      $ GetOpt.usageInfo header Flag.options
     Exception.throwM Exit.ExitSuccess
 
   Monad.when (Config.version config) $ do

--- a/source/library/CabalGild/Main.hs
+++ b/source/library/CabalGild/Main.hs
@@ -21,6 +21,7 @@ import qualified CabalGild.Type.Flag as Flag
 import qualified CabalGild.Type.Input as Input
 import qualified CabalGild.Type.Mode as Mode
 import qualified CabalGild.Type.Optional as Optional
+import qualified CabalGild.Type.Output as Output
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Data.ByteString as ByteString
@@ -124,5 +125,5 @@ mainWith name arguments = do
       Monad.when (outputLines /= inputLines) $
         Exception.throwM CheckFailure.CheckFailure
     Mode.Format -> do
-      let target = Optional.withDefault Nothing $ Config.output config
+      let target = Optional.withDefault Output.Stdout $ Config.output config
       MonadWrite.write target output

--- a/source/library/CabalGild/Main.hs
+++ b/source/library/CabalGild/Main.hs
@@ -79,13 +79,13 @@ mainWith name arguments = do
               "",
               "<https://github.com/tfausak/cabal-gild>"
             ]
-    MonadLog.logLn
+    MonadLog.info
       . List.dropWhileEnd Char.isSpace
       $ GetOpt.usageInfo header Flag.options
     Exception.throwM Exit.ExitSuccess
 
   Monad.when (Config.version config) $ do
-    MonadLog.logLn version
+    MonadLog.info version
     Exception.throwM Exit.ExitSuccess
 
   input <- MonadRead.read $ Config.input config

--- a/source/library/CabalGild/Main.hs
+++ b/source/library/CabalGild/Main.hs
@@ -19,6 +19,7 @@ import qualified CabalGild.Exception.ParseError as ParseError
 import qualified CabalGild.Type.Config as Config
 import qualified CabalGild.Type.Flag as Flag
 import qualified CabalGild.Type.Mode as Mode
+import qualified CabalGild.Type.Optional as Optional
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Data.ByteString as ByteString
@@ -72,7 +73,7 @@ mainWith name arguments = do
   config <- Config.fromFlags flags
   let version = Version.showVersion This.version
 
-  Monad.when (Config.help config) $ do
+  Monad.when (Optional.withDefault False $ Config.help config) $ do
     let header =
           unlines
             [ name <> " version " <> version,
@@ -84,28 +85,30 @@ mainWith name arguments = do
       $ GetOpt.usageInfo header Flag.options
     Exception.throwM Exit.ExitSuccess
 
-  Monad.when (Config.version config) $ do
+  Monad.when (Optional.withDefault False $ Config.version config) $ do
     MonadLog.info version
     Exception.throwM Exit.ExitSuccess
 
-  input <- MonadRead.read $ Config.input config
+  let source = Optional.withDefault Nothing $ Config.input config
+  input <- MonadRead.read source
   fields <-
     either (Exception.throwM . ParseError.ParseError) pure $
       Fields.readFields input
   let csv = GetCabalVersion.fromFields fields
       comments = ExtractComments.fromByteString input
+      path = Maybe.fromMaybe (Optional.withDefault "." $ Config.stdin config) source
   output <-
     ( StripBlanks.run
         Monad.>=> AttachComments.run
         Monad.>=> ReflowText.run csv
         Monad.>=> RemovePositions.run
-        Monad.>=> EvaluatePragmas.run (Maybe.fromMaybe (Config.stdin config) $ Config.input config)
+        Monad.>=> EvaluatePragmas.run path
         Monad.>=> FormatFields.run csv
         Monad.>=> Render.run
       )
       (fields, comments)
 
-  case Config.mode config of
+  case Optional.withDefault Mode.Format $ Config.mode config of
     Mode.Check -> do
       -- The input might have CRLF ("\r\n", 0x0d 0x0a) line endings, but the
       -- output will always have LF line endings. For the purposes of the check
@@ -118,4 +121,6 @@ mainWith name arguments = do
           inputLines = stripCR <$> Latin1.lines input
       Monad.when (outputLines /= inputLines) $
         Exception.throwM CheckFailure.CheckFailure
-    Mode.Format -> MonadWrite.write (Config.output config) output
+    Mode.Format -> do
+      let target = Optional.withDefault Nothing $ Config.output config
+      MonadWrite.write target output

--- a/source/library/CabalGild/Type/Config.hs
+++ b/source/library/CabalGild/Type/Config.hs
@@ -5,6 +5,7 @@ import qualified CabalGild.Type.Flag as Flag
 import qualified CabalGild.Type.Input as Input
 import qualified CabalGild.Type.Mode as Mode
 import qualified CabalGild.Type.Optional as Optional
+import qualified CabalGild.Type.Output as Output
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 
@@ -14,7 +15,7 @@ data Config = Config
   { help :: Optional.Optional Bool,
     input :: Optional.Optional Input.Input,
     mode :: Optional.Optional Mode.Mode,
-    output :: Optional.Optional (Maybe FilePath),
+    output :: Optional.Optional Output.Output,
     stdin :: Optional.Optional FilePath,
     version :: Optional.Optional Bool
   }
@@ -43,8 +44,8 @@ applyFlag config flag = case flag of
     m <- Mode.fromString s
     pure config {mode = Optional.Specific m}
   Flag.Output s -> case s of
-    "-" -> pure config {output = Optional.Specific Nothing}
-    _ -> pure config {output = Optional.Specific $ Just s}
+    "-" -> pure config {output = Optional.Specific Output.Stdout}
+    _ -> pure config {output = Optional.Specific $ Output.File s}
   Flag.Stdin s -> pure config {stdin = Optional.Specific s}
   Flag.Version b -> pure config {version = Optional.Specific b}
 

--- a/source/library/CabalGild/Type/Config.hs
+++ b/source/library/CabalGild/Type/Config.hs
@@ -37,15 +37,11 @@ initial =
 applyFlag :: (Exception.MonadThrow m) => Config -> Flag.Flag -> m Config
 applyFlag config flag = case flag of
   Flag.Help b -> pure config {help = Optional.Specific b}
-  Flag.Input s -> case s of
-    "-" -> pure config {input = Optional.Specific Input.Stdin}
-    _ -> pure config {input = Optional.Specific $ Input.File s}
+  Flag.Input s -> pure config {input = Optional.Specific $ Input.fromString s}
   Flag.Mode s -> do
     m <- Mode.fromString s
     pure config {mode = Optional.Specific m}
-  Flag.Output s -> case s of
-    "-" -> pure config {output = Optional.Specific Output.Stdout}
-    _ -> pure config {output = Optional.Specific $ Output.File s}
+  Flag.Output s -> pure config {output = Optional.Specific $ Output.fromString s}
   Flag.Stdin s -> pure config {stdin = Optional.Specific s}
   Flag.Version b -> pure config {version = Optional.Specific b}
 

--- a/source/library/CabalGild/Type/Config.hs
+++ b/source/library/CabalGild/Type/Config.hs
@@ -3,18 +3,19 @@ module CabalGild.Type.Config where
 
 import qualified CabalGild.Type.Flag as Flag
 import qualified CabalGild.Type.Mode as Mode
+import qualified CabalGild.Type.Optional as Optional
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 
 -- | This data type represents the configuration for the command line utility.
 -- Each field typically corresponds to a flag.
 data Config = Config
-  { help :: Bool,
-    input :: Maybe FilePath,
-    mode :: Mode.Mode,
-    output :: Maybe FilePath,
-    stdin :: FilePath,
-    version :: Bool
+  { help :: Optional.Optional Bool,
+    input :: Optional.Optional (Maybe FilePath),
+    mode :: Optional.Optional Mode.Mode,
+    output :: Optional.Optional (Maybe FilePath),
+    stdin :: Optional.Optional FilePath,
+    version :: Optional.Optional Bool
   }
   deriving (Eq, Show)
 
@@ -22,29 +23,29 @@ data Config = Config
 initial :: Config
 initial =
   Config
-    { help = False,
-      input = Nothing,
-      mode = Mode.Format,
-      output = Nothing,
-      stdin = ".",
-      version = False
+    { help = Optional.Default,
+      input = Optional.Default,
+      mode = Optional.Default,
+      output = Optional.Default,
+      stdin = Optional.Default,
+      version = Optional.Default
     }
 
 -- | Applies a flag to the config, returning the new config.
 applyFlag :: (Exception.MonadThrow m) => Config -> Flag.Flag -> m Config
 applyFlag config flag = case flag of
-  Flag.Help b -> pure config {help = b}
+  Flag.Help b -> pure config {help = Optional.Specific b}
   Flag.Input s -> case s of
-    "-" -> pure config {input = Nothing}
-    _ -> pure config {input = Just s}
+    "-" -> pure config {input = Optional.Specific Nothing}
+    _ -> pure config {input = Optional.Specific $ Just s}
   Flag.Mode s -> do
     m <- Mode.fromString s
-    pure config {mode = m}
+    pure config {mode = Optional.Specific m}
   Flag.Output s -> case s of
-    "-" -> pure config {output = Nothing}
-    _ -> pure config {output = Just s}
-  Flag.Stdin s -> pure config {stdin = s}
-  Flag.Version b -> pure config {version = b}
+    "-" -> pure config {output = Optional.Specific Nothing}
+    _ -> pure config {output = Optional.Specific $ Just s}
+  Flag.Stdin s -> pure config {stdin = Optional.Specific s}
+  Flag.Version b -> pure config {version = Optional.Specific b}
 
 -- | Converts a list of flags into a config by starting with 'initial' and
 -- repeatedly calling 'applyFlag'.

--- a/source/library/CabalGild/Type/Config.hs
+++ b/source/library/CabalGild/Type/Config.hs
@@ -2,6 +2,7 @@
 module CabalGild.Type.Config where
 
 import qualified CabalGild.Type.Flag as Flag
+import qualified CabalGild.Type.Input as Input
 import qualified CabalGild.Type.Mode as Mode
 import qualified CabalGild.Type.Optional as Optional
 import qualified Control.Monad as Monad
@@ -11,7 +12,7 @@ import qualified Control.Monad.Catch as Exception
 -- Each field typically corresponds to a flag.
 data Config = Config
   { help :: Optional.Optional Bool,
-    input :: Optional.Optional (Maybe FilePath),
+    input :: Optional.Optional Input.Input,
     mode :: Optional.Optional Mode.Mode,
     output :: Optional.Optional (Maybe FilePath),
     stdin :: Optional.Optional FilePath,
@@ -36,8 +37,8 @@ applyFlag :: (Exception.MonadThrow m) => Config -> Flag.Flag -> m Config
 applyFlag config flag = case flag of
   Flag.Help b -> pure config {help = Optional.Specific b}
   Flag.Input s -> case s of
-    "-" -> pure config {input = Optional.Specific Nothing}
-    _ -> pure config {input = Optional.Specific $ Just s}
+    "-" -> pure config {input = Optional.Specific Input.Stdin}
+    _ -> pure config {input = Optional.Specific $ Input.File s}
   Flag.Mode s -> do
     m <- Mode.fromString s
     pure config {mode = Optional.Specific m}

--- a/source/library/CabalGild/Type/Input.hs
+++ b/source/library/CabalGild/Type/Input.hs
@@ -6,3 +6,10 @@ data Input
   = Stdin
   | File FilePath
   deriving (Eq, Ord, Show)
+
+-- | Converts a string into an input. The string @"-"@ will be converted into
+-- 'Stdin', and any other string will be converted into 'File'.
+fromString :: String -> Input
+fromString s = case s of
+  "-" -> Stdin
+  _ -> File s

--- a/source/library/CabalGild/Type/Input.hs
+++ b/source/library/CabalGild/Type/Input.hs
@@ -1,0 +1,8 @@
+module CabalGild.Type.Input where
+
+-- | Represents an input stream, which can either be standard input (STDIN) or
+-- a file.
+data Input
+  = Stdin
+  | File FilePath
+  deriving (Eq, Ord, Show)

--- a/source/library/CabalGild/Type/Optional.hs
+++ b/source/library/CabalGild/Type/Optional.hs
@@ -1,0 +1,14 @@
+module CabalGild.Type.Optional where
+
+data Optional a
+  = Default
+  | Specific a
+  deriving (Eq, Show)
+
+withDefault :: a -> Optional a -> a
+withDefault = flip optional id
+
+optional :: b -> (a -> b) -> Optional a -> b
+optional b f o = case o of
+  Default -> b
+  Specific s -> f s

--- a/source/library/CabalGild/Type/Optional.hs
+++ b/source/library/CabalGild/Type/Optional.hs
@@ -1,13 +1,19 @@
 module CabalGild.Type.Optional where
 
+-- | Represents a value that may or may not be present. Isomorphic to 'Maybe'.
+-- Useful to distinguish between a value not being given and a value happening
+-- to be the same as the default.
 data Optional a
   = Default
   | Specific a
   deriving (Eq, Show)
 
+-- | Uses the provided default value if the optional is 'Default', otherwise
+-- gets the value out of the 'Specific'. Similar to 'Data.Maybe.fromMaybe'.
 withDefault :: a -> Optional a -> a
 withDefault = flip optional id
 
+-- | Basic destructor, similar to 'maybe'.
 optional :: b -> (a -> b) -> Optional a -> b
 optional b f o = case o of
   Default -> b

--- a/source/library/CabalGild/Type/Output.hs
+++ b/source/library/CabalGild/Type/Output.hs
@@ -1,0 +1,8 @@
+module CabalGild.Type.Output where
+
+-- | Represents an output stream, which can either be standard output
+-- (STDOUT) or a file.
+data Output
+  = Stdout
+  | File FilePath
+  deriving (Eq, Ord, Show)

--- a/source/library/CabalGild/Type/Output.hs
+++ b/source/library/CabalGild/Type/Output.hs
@@ -6,3 +6,10 @@ data Output
   = Stdout
   | File FilePath
   deriving (Eq, Ord, Show)
+
+-- | Converts a string into an output. The string @"-"@ will be converted into
+-- 'Stdout', and any other string will be converted into 'File'.
+fromString :: String -> Output
+fromString s = case s of
+  "-" -> Stdout
+  _ -> File s

--- a/source/library/CabalGild/Type/Severity.hs
+++ b/source/library/CabalGild/Type/Severity.hs
@@ -3,4 +3,5 @@ module CabalGild.Type.Severity where
 -- | Represents the severity of a log message.
 data Severity
   = Info
+  | Warn
   deriving (Eq, Show)

--- a/source/library/CabalGild/Type/Severity.hs
+++ b/source/library/CabalGild/Type/Severity.hs
@@ -1,5 +1,6 @@
 module CabalGild.Type.Severity where
 
+-- | Represents the severity of a log message.
 data Severity
   = Info
   deriving (Eq, Show)

--- a/source/library/CabalGild/Type/Severity.hs
+++ b/source/library/CabalGild/Type/Severity.hs
@@ -1,0 +1,5 @@
+module CabalGild.Type.Severity where
+
+data Severity
+  = Info
+  deriving (Eq, Show)

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1018,7 +1018,7 @@ newtype TestT m a = TestT
   deriving (Applicative, Functor, Monad)
 
 instance (Monad m) => MonadLog.MonadLog (TestT m) where
-  log = TestT . Trans.lift . RWST.tell . pure
+  logLn = TestT . Trans.lift . RWST.tell . pure
 
 instance (Monad m) => MonadRead.MonadRead (TestT m) where
   read k = do

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -6,6 +6,7 @@ import qualified CabalGild.Class.MonadWalk as MonadWalk
 import qualified CabalGild.Class.MonadWrite as MonadWrite
 import qualified CabalGild.Extra.String as String
 import qualified CabalGild.Main as Gild
+import qualified CabalGild.Type.Severity as Severity
 import qualified Control.Monad.Catch as Exception
 import qualified Control.Monad.Trans.Class as Trans
 import qualified Control.Monad.Trans.Except as ExceptT
@@ -1010,7 +1011,7 @@ type R = (S, Map.Map FilePath [FilePath])
 
 type S = Map.Map (Maybe FilePath) ByteString.ByteString
 
-type W = [String]
+type W = [(Severity.Severity, String)]
 
 newtype TestT m a = TestT
   { runTestT :: ExceptT.ExceptT E (RWST.RWST R W S m) a
@@ -1018,7 +1019,7 @@ newtype TestT m a = TestT
   deriving (Applicative, Functor, Monad)
 
 instance (Monad m) => MonadLog.MonadLog (TestT m) where
-  logLn = TestT . Trans.lift . RWST.tell . pure
+  logLn sev str = TestT . Trans.lift $ RWST.tell [(sev, str)]
 
 instance (Monad m) => MonadRead.MonadRead (TestT m) where
   read k = do

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -7,6 +7,7 @@ import qualified CabalGild.Class.MonadWrite as MonadWrite
 import qualified CabalGild.Extra.String as String
 import qualified CabalGild.Main as Gild
 import qualified CabalGild.Type.Input as Input
+import qualified CabalGild.Type.Output as Output
 import qualified CabalGild.Type.Severity as Severity
 import qualified Control.Monad.Catch as Exception
 import qualified Control.Monad.Trans.Class as Trans
@@ -51,7 +52,7 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
             Map.empty
     a `Hspec.shouldBe` Right ()
     w `Hspec.shouldBe` []
-    s `Hspec.shouldSatisfy` Map.member Nothing
+    s `Hspec.shouldSatisfy` Map.member Output.Stdout
 
   Hspec.it "writes to an output file" $ do
     let (a, s, w) =
@@ -61,7 +62,7 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
             Map.empty
     a `Hspec.shouldBe` Right ()
     w `Hspec.shouldBe` []
-    s `Hspec.shouldSatisfy` Map.member (Just "output.cabal")
+    s `Hspec.shouldSatisfy` Map.member (Output.File "output.cabal")
 
   Hspec.it "succeeds when checking formatted input" $ do
     let (a, s, w) =
@@ -957,7 +958,7 @@ expectGilded input expected = do
   a `Hspec.shouldBe` Right ()
   w `Hspec.shouldBe` []
   actual <- case Map.toList s of
-    [(Nothing, x)] -> pure x
+    [(Output.Stdout, x)] -> pure x
     _ -> fail $ "impossible: " <> show s
   actual `Hspec.shouldBe` String.toUtf8 expected
   -- After formatting, the output should not change if we format it again.
@@ -973,7 +974,7 @@ expectStable input = do
   a `Hspec.shouldBe` Right ()
   w `Hspec.shouldBe` []
   output <- case Map.toList s of
-    [(Nothing, x)] -> pure x
+    [(Output.Stdout, x)] -> pure x
     _ -> fail $ "impossible: " <> show s
   output `Hspec.shouldBe` input
 
@@ -989,7 +990,7 @@ expectDiscover files input expected = do
   a `Hspec.shouldBe` Right ()
   w `Hspec.shouldBe` []
   actual <- case Map.toList s of
-    [(Nothing, x)] -> pure x
+    [(Output.Stdout, x)] -> pure x
     _ -> fail $ "impossible: " <> show s
   actual `Hspec.shouldBe` String.toUtf8 expected
 
@@ -1010,7 +1011,7 @@ type E = Problem
 
 type R = (Map.Map Input.Input ByteString.ByteString, Map.Map FilePath [FilePath])
 
-type S = Map.Map (Maybe FilePath) ByteString.ByteString
+type S = Map.Map Output.Output ByteString.ByteString
 
 type W = [(Severity.Severity, String)]
 


### PR DESCRIPTION
There was a lot of refactoring to do here. And honestly after doing it, I'm not sure that this is the right way to go. Perhaps instead of emitting warnings, Gild should simply error out if the config is invalid. That would be a breaking change, but I think it's worth it. 