### PR TITLE
Avoid unnecessarily signing macOS binaries

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -179,10 +179,7 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "ls -l"
-        },
-        {
-          "run": "ls -l *"
+          "run": "sh -exc 'for f in */artifact.tar; do tar --extract --verbose --file $f; done'"
         },
         {
           "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/${{ env.PREFIX }}.tar.gz ."

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -179,6 +179,9 @@
           "uses": "actions/download-artifact@v4"
         },
         {
+          "run": "ls -l"
+        },
+        {
           "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/${{ env.PREFIX }}.tar.gz ."
         },
         {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -66,10 +66,13 @@
           "run": "codesign --sign - artifact/cabal-gild"
         },
         {
+          "run": "tar --create --file artifact.tar artifact"
+        },
+        {
           "uses": "actions/upload-artifact@v4",
           "with": {
             "name": "cabal-gild-${{ github.sha }}-${{ matrix.platform }}-${{ matrix.version }}-${{ matrix.ghc }}",
-            "path": "artifact"
+            "path": "artifact.tar"
           }
         },
         {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,7 +14,6 @@
           "id": "haskell",
           "uses": "haskell-actions/setup@v2",
           "with": {
-            "cabal-version": "3.10.2.1",
             "ghc-version": "${{ matrix.ghc }}"
           }
         },

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -180,7 +180,7 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "sh -exc 'for f in */artifact.tar; do tar --extract --file $f --verbose; done'"
+          "run": "sh -exc 'for d in *; do cd $d; tar --extract --file artifact.tar --verbose; cd ..; done'"
         },
         {
           "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/artifact/${{ env.PREFIX }}.tar.gz ."

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -62,7 +62,7 @@
           "run": "cp $( cabal list-bin cabal-gild ) artifact"
         },
         {
-          "if": "matrix.platform == 'macos'",
+          "if": "${{ matrix.platform == 'macos' }}",
           "run": "codesign --sign - artifact/cabal-gild"
         },
         {
@@ -169,7 +169,7 @@
       "env": {
         "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
       },
-      "if": "github.event_name == 'release'",
+      "if": "${{ github.event_name == 'release' }}",
       "name": "Release",
       "needs": "build",
       "runs-on": "ubuntu-22.04",

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -62,10 +62,6 @@
           "run": "cp $( cabal list-bin cabal-gild ) artifact"
         },
         {
-          "if": "${{ matrix.platform == 'macos' }}",
-          "run": "codesign --sign - artifact/cabal-gild"
-        },
-        {
           "run": "tar --create --file artifact.tar --verbose artifact"
         },
         {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -66,7 +66,7 @@
           "run": "codesign --sign - artifact/cabal-gild"
         },
         {
-          "run": "tar --create --file artifact.tar artifact"
+          "run": "tar --create --file artifact.tar --verbose artifact"
         },
         {
           "uses": "actions/upload-artifact@v4",
@@ -179,10 +179,10 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "sh -exc 'for f in */artifact.tar; do tar --extract --verbose --file $f; done'"
+          "run": "sh -exc 'for f in */artifact.tar; do tar --extract --file $f --verbose; done'"
         },
         {
-          "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/${{ env.PREFIX }}.tar.gz ."
+          "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/artifact/${{ env.PREFIX }}.tar.gz ."
         },
         # {
         #   "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tar.gz cabal-gild",
@@ -193,8 +193,8 @@
         #   "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8"
         # },
         {
-          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-linux-x64.tar.gz cabal-gild",
-          "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8"
+          "run": "tar --auto-compress --create --file ../../${{ env.PREFIX }}-linux-x64.tar.gz --verbose cabal-gild",
+          "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/artifact"
         },
         # {
         #   "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-win32-x64.tar.gz cabal-gild.exe",

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -182,6 +182,9 @@
           "run": "ls -l"
         },
         {
+          "run": "tar --extract --verbose --file cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8"
+        },
+        {
           "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/${{ env.PREFIX }}.tar.gz ."
         },
         {

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -171,7 +171,6 @@
       "env": {
         "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
       },
-      "if": "${{ github.event_name == 'release' }}",
       "name": "Release",
       "needs": "build",
       "runs-on": "ubuntu-22.04",
@@ -199,12 +198,14 @@
           "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8"
         },
         {
+          "if": "${{ github.event_name == 'release' }}",
           "uses": "softprops/action-gh-release@v1",
           "with": {
             "files": "${{ env.PREFIX }}*.tar.gz"
           }
         },
         {
+          "if": "${{ github.event_name == 'release' }}",
           "run": "cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' ${{ env.PREFIX }}.tar.gz"
         }
       ]

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -180,23 +180,23 @@
           "uses": "actions/download-artifact@v4"
         },
         {
-          "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8.1/${{ env.PREFIX }}.tar.gz ."
+          "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/${{ env.PREFIX }}.tar.gz ."
         },
         {
           "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tar.gz cabal-gild",
-          "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8.1"
+          "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8"
         },
         {
           "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-arm64.tar.gz cabal-gild",
-          "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8.1"
+          "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8"
         },
         {
           "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-linux-x64.tar.gz cabal-gild",
-          "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8.1"
+          "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8"
         },
         {
           "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-win32-x64.tar.gz cabal-gild.exe",
-          "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8.1"
+          "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8"
         },
         {
           "uses": "softprops/action-gh-release@v1",

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -182,7 +182,7 @@
           "run": "ls -l"
         },
         {
-          "run": "tar --extract --verbose --file cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8"
+          "run": "ls -l *"
         },
         {
           "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/${{ env.PREFIX }}.tar.gz ."

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -85,21 +85,21 @@
       "strategy": {
         "matrix": {
           "include": [
-            # {
-            #   "ghc": "9.8",
-            #   "platform": "macos",
-            #   "version": 13
-            # },
-            # {
-            #   "ghc": "9.8",
-            #   "platform": "macos",
-            #   "version": 14
-            # },
-            # {
-            #   "ghc": "9.4",
-            #   "platform": "ubuntu",
-            #   "version": 22.04
-            # },
+            {
+              "ghc": "9.8",
+              "platform": "macos",
+              "version": 13
+            },
+            {
+              "ghc": "9.8",
+              "platform": "macos",
+              "version": 14
+            },
+            {
+              "ghc": "9.4",
+              "platform": "ubuntu",
+              "version": 22.04
+            },
             {
               "ghc": "9.6",
               "platform": "ubuntu",
@@ -110,11 +110,11 @@
               "platform": "ubuntu",
               "version": 22.04
             },
-            # {
-            #   "ghc": "9.8",
-            #   "platform": "windows",
-            #   "version": 2022
-            # }
+            {
+              "ghc": "9.8",
+              "platform": "windows",
+              "version": 2022
+            }
           ]
         }
       }
@@ -169,7 +169,8 @@
     },
     "release": {
       "env": {
-        "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
+        # "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
+        "PREFIX": "cabal-gild-1.1.0.0"
       },
       "name": "Release",
       "needs": "build",
@@ -184,22 +185,22 @@
         {
           "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/artifact/${{ env.PREFIX }}.tar.gz ."
         },
-        # {
-        #   "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tar.gz cabal-gild",
-        #   "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8"
-        # },
-        # {
-        #   "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-arm64.tar.gz cabal-gild",
-        #   "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8"
-        # },
+        {
+          "run": "tar --auto-compress --create --file ../../${{ env.PREFIX }}-darwin-x64.tar.gz --verbose cabal-gild",
+          "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8/artifact"
+        },
+        {
+          "run": "tar --auto-compress --create --file ../../${{ env.PREFIX }}-darwin-arm64.tar.gz --verbose cabal-gild",
+          "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8/artifact"
+        },
         {
           "run": "tar --auto-compress --create --file ../../${{ env.PREFIX }}-linux-x64.tar.gz --verbose cabal-gild",
           "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/artifact"
         },
-        # {
-        #   "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-win32-x64.tar.gz cabal-gild.exe",
-        #   "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8"
-        # },
+        {
+          "run": "tar --auto-compress --create --file ../../${{ env.PREFIX }}-win32-x64.tar.gz --verbose cabal-gild.exe",
+          "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8/artifact"
+        },
         {
           "if": "${{ github.event_name == 'release' }}",
           "uses": "softprops/action-gh-release@v1",

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -85,21 +85,21 @@
       "strategy": {
         "matrix": {
           "include": [
-            {
-              "ghc": "9.8",
-              "platform": "macos",
-              "version": 13
-            },
-            {
-              "ghc": "9.8",
-              "platform": "macos",
-              "version": 14
-            },
-            {
-              "ghc": "9.4",
-              "platform": "ubuntu",
-              "version": 22.04
-            },
+            # {
+            #   "ghc": "9.8",
+            #   "platform": "macos",
+            #   "version": 13
+            # },
+            # {
+            #   "ghc": "9.8",
+            #   "platform": "macos",
+            #   "version": 14
+            # },
+            # {
+            #   "ghc": "9.4",
+            #   "platform": "ubuntu",
+            #   "version": 22.04
+            # },
             {
               "ghc": "9.6",
               "platform": "ubuntu",
@@ -110,11 +110,11 @@
               "platform": "ubuntu",
               "version": 22.04
             },
-            {
-              "ghc": "9.8",
-              "platform": "windows",
-              "version": 2022
-            }
+            # {
+            #   "ghc": "9.8",
+            #   "platform": "windows",
+            #   "version": 2022
+            # }
           ]
         }
       }

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -169,9 +169,9 @@
     },
     "release": {
       "env": {
-        # "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
-        "PREFIX": "cabal-gild-1.1.0.0"
+        "PREFIX": "cabal-gild-${{ github.event.release.tag_name }}"
       },
+      "if": "${{ github.event_name == 'release' }}",
       "name": "Release",
       "needs": "build",
       "runs-on": "ubuntu-22.04",
@@ -202,14 +202,12 @@
           "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8/artifact"
         },
         {
-          "if": "${{ github.event_name == 'release' }}",
           "uses": "softprops/action-gh-release@v1",
           "with": {
             "files": "${{ env.PREFIX }}*.tar.gz"
           }
         },
         {
-          "if": "${{ github.event_name == 'release' }}",
           "run": "cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' ${{ env.PREFIX }}.tar.gz"
         }
       ]

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -83,33 +83,32 @@
         "matrix": {
           "include": [
             {
-              "ghc": "9.8.1",
+              "ghc": "9.8",
               "platform": "macos",
               "version": 13
             },
             {
-              "ghc": "9.8.1",
+              "ghc": "9.8",
               "platform": "macos",
               "version": 14
             },
             {
-              "ghc": "9.4.8",
+              "ghc": "9.4",
               "platform": "ubuntu",
               "version": 22.04
             },
             {
-              "ghc": "9.6.4",
+              "ghc": "9.6",
               "platform": "ubuntu",
               "version": 22.04
             },
             {
-              "ghc": "9.8.1",
+              "ghc": "9.8",
               "platform": "ubuntu",
               "version": 22.04
             },
             {
-              "extension": ".exe",
-              "ghc": "9.8.1",
+              "ghc": "9.8",
               "platform": "windows",
               "version": 2022
             }

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -184,22 +184,22 @@
         {
           "run": "cp cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8/${{ env.PREFIX }}.tar.gz ."
         },
-        {
-          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tar.gz cabal-gild",
-          "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8"
-        },
-        {
-          "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-arm64.tar.gz cabal-gild",
-          "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8"
-        },
+        # {
+        #   "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-x64.tar.gz cabal-gild",
+        #   "working-directory": "cabal-gild-${{ github.sha }}-macos-13-9.8"
+        # },
+        # {
+        #   "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-darwin-arm64.tar.gz cabal-gild",
+        #   "working-directory": "cabal-gild-${{ github.sha }}-macos-14-9.8"
+        # },
         {
           "run": "chmod +x cabal-gild && tar --auto-compress --create --file ../${{ env.PREFIX }}-linux-x64.tar.gz cabal-gild",
           "working-directory": "cabal-gild-${{ github.sha }}-ubuntu-22.04-9.8"
         },
-        {
-          "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-win32-x64.tar.gz cabal-gild.exe",
-          "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8"
-        },
+        # {
+        #   "run": "chmod +x cabal-gild.exe && tar --auto-compress --create --file ../${{ env.PREFIX }}-win32-x64.tar.gz cabal-gild.exe",
+        #   "working-directory": "cabal-gild-${{ github.sha }}-windows-2022-9.8"
+        # },
         {
           "if": "${{ github.event_name == 'release' }}",
           "uses": "softprops/action-gh-release@v1",


### PR DESCRIPTION
I suspected that the code signing I added in #25 for macOS was unnecessary. So I figured I could remove it. To make testing easier on myself, I changed the artifacts to be tarballs rather than directories. That retains permissions, which means I can just download the artifact and attempt to run the binary. 

Aside from that I just made some quality of life changes to how CI works. 