### PR TITLE
Fix formatting of conditionals

### DIFF
--- a/source/library/CabalGild/Action/Render.hs
+++ b/source/library/CabalGild/Action/Render.hs
@@ -59,8 +59,8 @@ field i f = case f of
               }
           <> fieldLines (i + 1) fls
   Fields.Section n sas fs ->
-    Lens.set Block.lineBeforeLens True
-      . Lens.set Block.lineAfterLens True
+    Lens.set Block.lineBeforeLens (not $ Name.isElif n || Name.isElse n)
+      . Lens.set Block.lineAfterLens (not $ Name.isIf n || Name.isElif n)
       $ comments i (Name.annotation n)
         <> comments i (concatMap SectionArg.annotation sas)
         <> Block.fromLine

--- a/source/library/CabalGild/Extra/Name.hs
+++ b/source/library/CabalGild/Extra/Name.hs
@@ -1,5 +1,6 @@
 module CabalGild.Extra.Name where
 
+import qualified CabalGild.Extra.String as String
 import qualified Distribution.Compat.Lens as Lens
 import qualified Distribution.Fields as Fields
 
@@ -14,3 +15,15 @@ annotationLens f s = fmap (\a -> Fields.Name a $ value s) . f $ annotation s
 -- | Extracts the value from the given 'Fields.Name'.
 value :: Fields.Name a -> Fields.FieldName
 value (Fields.Name _ x) = x
+
+-- | Returns true when the name is @"if"@, false otherwise.
+isIf :: Fields.Name a -> Bool
+isIf = (== String.toUtf8 "if") . value
+
+-- | Returns true when the name is @"elif"@, false otherwise.
+isElif :: Fields.Name a -> Bool
+isElif = (== String.toUtf8 "elif") . value
+
+-- | Returns true when the name is @"else"@, false otherwise.
+isElse :: Fields.Name a -> Bool
+isElse = (== String.toUtf8 "else") . value

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -970,6 +970,31 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "s{t{}}"
       "s\n  t\n"
 
+  Hspec.it "groups 'else' with 'if'" $ do
+    expectGilded
+      "if p\n a\nelse\n b"
+      "if p\n  a\nelse\n  b\n"
+
+  Hspec.it "groups 'elif' with 'if'" $ do
+    expectGilded
+      "if p\n a\nelif q\n b"
+      "if p\n  a\nelif q\n  b\n"
+
+  Hspec.it "groups 'else' with 'elif'" $ do
+    expectGilded
+      "if p\n a\nelif q\n b\nelse\n c"
+      "if p\n  a\nelif q\n  b\nelse\n  c\n"
+
+  Hspec.it "does not group 'else' with anything else" $ do
+    expectGilded
+      "library\nelse p\n a"
+      "library\n\nelse p\n  a\n"
+
+  Hspec.it "does not group 'elif' with anything else" $ do
+    expectGilded
+      "library\nelif p\n a"
+      "library\n\nelif p\n  a\n"
+
 expectGilded :: (Stack.HasCallStack) => String -> String -> Hspec.Expectation
 expectGilded input expected = do
   let (a, s, w) =


### PR DESCRIPTION
As discovered in #40. 

``` cabal
-- before
if p
  t

else
  f
```

``` cabal
-- after
if p
  t
else
  f
```

I generally want to avoid special-casing things, but conditionals feel like a reasonable exception. The `else` conceptually belongs to the `if` above it. Separating them by an extra space makes things more confusing. 