### PR TITLE
Fix bug that incorrectly put blank line after empty field

### DIFF
--- a/source/library/CabalGild/Unstable/Action/Render.hs
+++ b/source/library/CabalGild/Unstable/Action/Render.hs
@@ -53,7 +53,7 @@ field i f = case f of
                    $ fieldLine i fl
                )
     _ ->
-      Lens.set Block.lineAfterLens True $
+      Lens.set Block.lineAfterLens (not $ null fls) $
         comments i (snd $ Name.annotation n)
           <> Block.fromLine
             Line.Line

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1124,6 +1124,11 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "library\n -- cabal-gild: discover .\n exposed-modules:\n  ..."
       "library\n  -- cabal-gild: discover .\n  exposed-modules:\n    M\n"
 
+  Hspec.it "does not put a blank line after an empty field" $ do
+    expectGilded
+      "f:\ng: a"
+      "f:\ng: a\n"
+
 shouldBeFailure ::
   (Stack.HasCallStack, Eq e, Exception.Exception e, Show a) =>
   Either Exception.SomeException a ->


### PR DESCRIPTION
Fixes #61. 

Before:

``` cabal
f:

g: a
```

After:

``` cabal
f:
g: a
```