### PR TITLE
Allow including patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,44 +177,69 @@ Gild supports special comments in package descriptions that act as pragmas.
 Each pragma starts with `-- cabal-gild:`. Pragmas must be the last comment
 before a field.
 
-- `-- cabal-gild: discover [DIRECTORY ...]`: This pragma will discover any
-  Haskell files in any of the given directories and use those to populate the
-  list of modules or signatures. If no directories are given, defaults to `.`
-  (the current directory). For example, given this input:
+#### `discover`
 
-  ``` cabal
-  library
-    -- cabal-gild: discover source/library
-    exposed-modules: ...
-  ```
+```
+-- cabal-gild: discover [DIRECTORY ...] [--include=PATTERN ...] [--exclude=PATTERN ...]
+```
 
-  Assuming there is a single Haskell file at `source/library/M.hs`, Gild will
-  produce this output:
+This pragma will discover any Haskell files in any of the given directories and
+use those to populate the list of modules or signatures. If no directories are
+given, defaults to `.` (the directory of the package description). For example,
+given this input:
 
-  ``` cabal
-  library
-    -- cabal-gild: discover source/library
-    exposed-modules: M
-  ```
+``` cabal
+library
+  -- cabal-gild: discover
+  exposed-modules: ...
+```
 
-  This pragma only works with the `exposed-modules`, `other-modules`, and
-  `signatures` fields. It will be ignored on all other fields.
+Assuming there is a single Haskell file at `Example.hs`, Gild will produce this
+output:
 
-  Any existing modules or signatures in the list will be ignored. The entire
-  field will be replaced. This means adding, removing, and renaming modules or
-  signatures should be handled automatically.
+``` cabal
+library
+  -- cabal-gild: discover
+  exposed-modules: Example
+```
 
-  This pragma searches for files with any of the following extensions: `*.chs`,
-  `*.cpphs`, `*.gc`, `*.hs`, `*.hsc`, `*.hsig`, `*.lhs`, `*.lhsig`, `*.ly`,
-  `*.x`, or `*.y`,
+This pragma only works with the `exposed-modules`, `other-modules`, and
+`signatures` fields. It will be ignored on all other fields.
 
-  Directories can be quoted if they contain spaces.
+Any existing modules or signatures in the list will be ignored. The entire
+field will be replaced. This means adding, removing, and renaming modules or
+signatures should be handled automatically.
 
-  Discovered modules can be ignored by using the `--exclude=FILE` option. For
-  example:
+This pragma searches for files with any of the following extensions: `*.chs`,
+`*.cpphs`, `*.gc`, `*.hs`, `*.hsc`, `*.hsig`, `*.lhs`, `*.lhsig`, `*.ly`,
+`*.x`, or `*.y`,
 
-  ``` cabal
-  library
-    -- cabal-gild: discover source/library --exclude=source/library/Foo/Bar.hs
-    exposed-modules: ...
-  ```
+Directories can be quoted if they contain spaces. For example:
+
+``` cabal
+library
+  -- cabal-gild: discover "my modules"
+  exposed-modules: ...
+```
+
+By default, all files in any of the given directories are considered for
+discovery. To explicitly include only certain files, use the
+`--include=PATTERN` option. For example:
+
+``` cabal
+library
+  -- cabal-gild: discover --include=**/*Spec.hs
+  other-modules: ...
+```
+
+Files can be excluded from discovery by using the `--exclude=PATTERN` option.
+For example:
+
+``` cabal
+library
+  -- cabal-gild: discover --exclude=**/*Spec.hs
+  exposed-modules: ...
+```
+
+If a file would match both the `--include` pattern and the `--exclude` pattern,
+it will be excluded.

--- a/source/library/CabalGild/Unstable/Action/EvaluatePragmas.hs
+++ b/source/library/CabalGild/Unstable/Action/EvaluatePragmas.hs
@@ -83,14 +83,9 @@ discover p n fls ds = do
   let exclusions = List.nubOrd $ fmap (normalize . FilePath.combine root) excs
       inclusions =
         List.nubOrd
-          . concatMap (\i -> fmap (normalize . flip FilePath.combine i) directories)
+          . fmap (normalize . FilePath.combine root)
           $ if null incs then ["**"] else incs
-  files <-
-    Trans.lift $
-      MonadWalk.walk
-        "."
-        inclusions
-        exclusions
+  files <- Trans.lift $ MonadWalk.walk "." inclusions exclusions
   let comments = concatMap (snd . FieldLine.annotation) fls
       position =
         maybe (fst $ Name.annotation n) (fst . FieldLine.annotation) $

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1397,6 +1397,18 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "f:\ng: a"
       "f:\ng: a\n"
 
+  Hspec.it "supports including a module" $ do
+    expectDiscover
+      [["M.hs"], ["N.hs"]]
+      "library\n -- cabal-gild: discover --include M.hs\n exposed-modules:"
+      "library\n  -- cabal-gild: discover --include M.hs\n  exposed-modules: M\n"
+
+  Hspec.it "supports including a pattern" $ do
+    expectDiscover
+      [["M1.hs"], ["M2.hs"], ["N.hs"]]
+      "library\n -- cabal-gild: discover --include M*.hs\n exposed-modules:"
+      "library\n  -- cabal-gild: discover --include M*.hs\n  exposed-modules:\n    M1\n    M2\n"
+
   Hspec.around_ withTemporaryDirectory
     . Hspec.it "discovers modules on the file system"
     $ do


### PR DESCRIPTION
Fixes #67. 

This is still a draft because I need more tests. In particular I need to test:

- Including a pattern with multiple directories, like `discover a b --include c`.
- Including multiple patterns, like `discover --include a --include b`.
- Both including and excluding, like `discover --include a --exclude b`.