### PR TITLE
Allow discovering more fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,9 @@ before a field.
 -- cabal-gild: discover [DIRECTORY ...] [--include=PATTERN ...] [--exclude=PATTERN ...]
 ```
 
-This pragma will discover any Haskell files in any of the given directories and
-use those to populate the list of modules or signatures. If no directories are
-given, defaults to `.` (the directory of the package description). For example,
-given this input:
+This pragma will discover files in any of the given directories. If no
+directories are given, defaults to `.` (the directory of the package
+description). For example, given this input:
 
 ``` cabal
 library
@@ -203,16 +202,43 @@ library
   exposed-modules: Example
 ```
 
-This pragma only works with the `exposed-modules`, `other-modules`, and
-`signatures` fields. It will be ignored on all other fields.
+This pragma works with the following fields:
 
-Any existing modules or signatures in the list will be ignored. The entire
-field will be replaced. This means adding, removing, and renaming modules or
-signatures should be handled automatically.
+- `asm-sources`
+- `c-sources`
+- `cxx-sources`
+- `data-files`
+- `exposed-modules`
+- `extra-doc-files`
+- `extra-source-files`
+- `includes`
+- `install-includes`
+- `js-sources`
+- `license-files`
+- `other-modules`
+- `signatures`
 
-This pragma searches for files with any of the following extensions: `*.chs`,
-`*.cpphs`, `*.gc`, `*.hs`, `*.hsc`, `*.hsig`, `*.lhs`, `*.lhsig`, `*.ly`,
-`*.x`, or `*.y`,
+It will be ignored on all other fields. For the `exposed-modules`,
+`other-modules`, and `signatures` fields, only files with the following
+extensions will be discovered:
+
+- `*.chs`
+- `*.cpphs`
+- `*.gc`
+- `*.hs`
+- `*.hsc`
+- `*.hsig`
+- `*.lhs`
+- `*.lhsig`
+- `*.ly`
+- `*.x`
+- `*.y`
+
+For all other fields, files with any extension will be discovered.
+
+Any existing files, modules, or signatures in the field will be ignored. The
+entire field will be replaced. This means adding, removing, and renaming files
+should be handled automatically.
 
 Directories can be quoted if they contain spaces. For example:
 

--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -108,6 +108,7 @@ library
     CabalGild.Unstable.Type.Config
     CabalGild.Unstable.Type.Context
     CabalGild.Unstable.Type.Dependency
+    CabalGild.Unstable.Type.DiscoverTarget
     CabalGild.Unstable.Type.ExeDependency
     CabalGild.Unstable.Type.Extension
     CabalGild.Unstable.Type.Flag

--- a/source/library/CabalGild/Unstable/Type/DiscoverTarget.hs
+++ b/source/library/CabalGild/Unstable/Type/DiscoverTarget.hs
@@ -1,0 +1,6 @@
+module CabalGild.Unstable.Type.DiscoverTarget where
+
+data DiscoverTarget
+  = Files
+  | Modules
+  deriving (Eq, Show)

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -1457,6 +1457,66 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
     w `Hspec.shouldBe` []
     s `Hspec.shouldBe` Map.singleton Output.Stdout (String.toUtf8 "library\n  -- cabal-gild: discover src --include src/M.hs\n  exposed-modules: M\n")
 
+  Hspec.it "discovers asm-sources" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\nasm-sources:"
+      "-- cabal-gild: discover\nasm-sources: example.txt\n"
+
+  Hspec.it "discovers c-sources" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\nc-sources:"
+      "-- cabal-gild: discover\nc-sources: example.txt\n"
+
+  Hspec.it "discovers cxx-sources" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\ncxx-sources:"
+      "-- cabal-gild: discover\ncxx-sources: example.txt\n"
+
+  Hspec.it "discovers data-files" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\ndata-files:"
+      "-- cabal-gild: discover\ndata-files: example.txt\n"
+
+  Hspec.it "discovers extra-doc-files" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\nextra-doc-files:"
+      "-- cabal-gild: discover\nextra-doc-files: example.txt\n"
+
+  Hspec.it "discovers extra-source-files" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\nextra-source-files:"
+      "-- cabal-gild: discover\nextra-source-files: example.txt\n"
+
+  Hspec.it "discovers includes" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\nincludes:"
+      "-- cabal-gild: discover\nincludes: example.txt\n"
+
+  Hspec.it "discovers install-includes" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\ninstall-includes:"
+      "-- cabal-gild: discover\ninstall-includes: example.txt\n"
+
+  Hspec.it "discovers js-sources" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\njs-sources:"
+      "-- cabal-gild: discover\njs-sources: example.txt\n"
+
+  Hspec.it "discovers license-files" $ do
+    expectDiscover
+      [["example.txt"]]
+      "-- cabal-gild: discover\nlicense-files:"
+      "-- cabal-gild: discover\nlicense-files: example.txt\n"
+
   Hspec.around_ withTemporaryDirectory
     . Hspec.it "discovers modules on the file system"
     $ do


### PR DESCRIPTION
Fixes #68. 

Some of these fields could perhaps have more reasonable default inclusion filters. For example, `c-sources` could match only `**/*.c` and `**/*.h` by default. However it felt less surprising to simply discover any files in the given directories. I suspect that will work for most people. And if not, it's easy enough to throw a `--include=...` on there.