### PR TITLE
Always float comments to the top of field values

### DIFF
--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -419,7 +419,7 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
   Hspec.it "formats a comment in a field's value" $ do
     expectGilded
       "f:\n 1\n -- c\n 2"
-      "f:\n  1\n  -- c\n  2\n"
+      "f:\n  -- c\n  1\n  2\n"
 
   Hspec.it "formats a comment after a field's value" $ do
     expectGilded
@@ -512,12 +512,12 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       Hspec.it "does not insert extra blank lines before comments" $ do
         expectGilded
           "cabal-version: 3.0\ndescription:\n -- c\n 1\n -- d\n 2"
-          "cabal-version: 3.0\ndescription:\n  -- c\n  1\n  -- d\n  2\n"
+          "cabal-version: 3.0\ndescription:\n  -- c\n  -- d\n  1\n  2\n"
 
       Hspec.it "does not consider comments for indentation" $ do
         expectGilded
           "cabal-version: 3.0\ndescription:\n  1\n -- c\n    2"
-          "cabal-version: 3.0\ndescription:\n  1\n  -- c\n    2\n"
+          "cabal-version: 3.0\ndescription:\n  -- c\n  1\n    2\n"
 
   Hspec.it "properly formats conditionals" $ do
     expectGilded
@@ -1516,6 +1516,16 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       [["example.txt"]]
       "-- cabal-gild: discover\nlicense-files:"
       "-- cabal-gild: discover\nlicense-files: example.txt\n"
+
+  Hspec.it "floats comments on unknown fields" $ do
+    expectGilded
+      "unknown-field:\n the\n -- some comment\n value"
+      "unknown-field:\n  -- some comment\n  the\n  value\n"
+
+  Hspec.it "floats comments when parsing field fails" $ do
+    expectGilded
+      "build-depends:\n >> no\n -- comment\n parse"
+      "build-depends:\n  -- comment\n  >> no\n  parse\n"
 
   Hspec.around_ withTemporaryDirectory
     . Hspec.it "discovers modules on the file system"


### PR DESCRIPTION
Fixes #70. 

Previously Gild would only float comments to the top of a field if Gild knew how to parse the field (like `build-depends`) and the field parsed successfully. Otherwise Gild would leave the comments where they were (although it would re-indent them). Now Gild will always pull all comments up to the top of a field, regardless of if Gild knows how to parse the field or if the parsing succeeded. 

This is a change in behavior. Hopefully it's easier for users to understand how Gild behaves. 

Before:

``` cabal
some-field:
  foo
  -- bar
  qux
```

After:

``` cabal
some-field:
  -- bar
  foo
  qux
```

In the future, it's possible that Gild will make an effort to keep comments where they were. However in general this is a difficult problem and in some cases it doesn't have a clear answer. So for now this predictable behavior is preferable. 