### PR TITLE
Emit warnings when overriding options

### DIFF
--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -61,6 +61,7 @@ library
     exceptions ^>=0.10.7,
     filepath ^>=1.4.100.1 || ^>=1.5.2.0,
     filepattern ^>=0.1.3,
+    mtl ^>=2.3.1,
     parsec ^>=3.1.16.1,
     pretty ^>=1.1.3.6,
     text ^>=2.0.2 || ^>=2.1,
@@ -128,6 +129,7 @@ library
     CabalGild.Unstable.Type.PkgconfigVersionRange
     CabalGild.Unstable.Type.Pragma
     CabalGild.Unstable.Type.Set
+    CabalGild.Unstable.Type.Severity
     CabalGild.Unstable.Type.SomeParsecParser
     CabalGild.Unstable.Type.TestedWith
     CabalGild.Unstable.Type.Variable

--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -82,6 +82,7 @@ library
     CabalGild.Unstable.Class.MonadRead
     CabalGild.Unstable.Class.MonadWalk
     CabalGild.Unstable.Class.MonadWrite
+    CabalGild.Unstable.Class.Warning
     CabalGild.Unstable.Exception.CheckFailure
     CabalGild.Unstable.Exception.InvalidLeniency
     CabalGild.Unstable.Exception.InvalidMode
@@ -132,9 +133,12 @@ library
     CabalGild.Unstable.Type.Set
     CabalGild.Unstable.Type.Severity
     CabalGild.Unstable.Type.SomeParsecParser
+    CabalGild.Unstable.Type.SomeWarning
     CabalGild.Unstable.Type.TestedWith
     CabalGild.Unstable.Type.Variable
     CabalGild.Unstable.Type.VersionRange
+    CabalGild.Unstable.Warning.UnexpectedArgument
+    CabalGild.Unstable.Warning.UnknownOption
 
   hs-source-dirs: source/library
   other-modules: Paths_cabal_gild

--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -96,6 +96,7 @@ library
     CabalGild.Unstable.Extra.Either
     CabalGild.Unstable.Extra.Field
     CabalGild.Unstable.Extra.FieldLine
+    CabalGild.Unstable.Extra.FilePath
     CabalGild.Unstable.Extra.List
     CabalGild.Unstable.Extra.ModuleName
     CabalGild.Unstable.Extra.Name

--- a/source/library/CabalGild/Unstable/Action/AttachComments.hs
+++ b/source/library/CabalGild/Unstable/Action/AttachComments.hs
@@ -55,7 +55,7 @@ fieldLine (Fields.FieldLine p bs) =
 
 -- | Attaches comments to a section argument. Note that section arguments
 -- cannot actually have comments attached. That's because section arguments
--- must be on -- the same line as the section name, so all comments will end up
+-- must be on the same line as the section name, so all comments will end up
 -- attached to the name.
 sectionArg ::
   (Ord p) =>

--- a/source/library/CabalGild/Unstable/Action/FormatFields.hs
+++ b/source/library/CabalGild/Unstable/Action/FormatFields.hs
@@ -77,6 +77,8 @@ field csv f = case f of
             else sas
      in Fields.Section n newSas $ fmap (field csv) fs
 
+-- | Returns 'True' if the field name is a conditional. @if@ is always one, and
+-- @elif@ is one for Cabal versions 2.2 and later.
 isConditional :: CabalSpecVersion.CabalSpecVersion -> Fields.Name p -> Bool
 isConditional csv n =
   Name.isIf n
@@ -102,6 +104,8 @@ fieldLines csv position fls SPP.SomeParsecParser {SPP.parsec = parsec, SPP.prett
         . PrettyPrint.renderStyle style
         $ pretty csv r
 
+-- | Collects comments from the given field lines (see 'collectComments') and
+-- attaches them all to the first one.
 floatComments ::
   p ->
   [Fields.FieldLine (p, [c])] ->
@@ -112,6 +116,8 @@ floatComments p fls =
     (True : repeat False)
     fls
 
+-- | Collects all comments from the given field lines. Their relative order
+-- will be maintained.
 collectComments :: [Fields.FieldLine (p, [c])] -> [c]
 collectComments = concatMap (snd . FieldLine.annotation)
 

--- a/source/library/CabalGild/Unstable/Class/MonadLog.hs
+++ b/source/library/CabalGild/Unstable/Class/MonadLog.hs
@@ -1,10 +1,21 @@
 module CabalGild.Unstable.Class.MonadLog where
 
+import qualified CabalGild.Unstable.Type.Severity as Severity
+import qualified System.IO as IO
+
 -- | A 'Monad' that can also log messages.
 class (Monad m) => MonadLog m where
   -- | Logs the given message followed by a newline.
-  logLn :: String -> m ()
+  logLn :: Severity.Severity -> String -> m ()
 
 -- | Uses 'putStrLn'.
 instance MonadLog IO where
-  logLn = putStrLn
+  logLn severity = case severity of
+    Severity.Info -> IO.putStrLn
+    Severity.Warn -> IO.hPutStrLn IO.stderr
+
+info :: (MonadLog m) => String -> m ()
+info = logLn Severity.Info
+
+warn :: (MonadLog m) => String -> m ()
+warn = logLn Severity.Warn

--- a/source/library/CabalGild/Unstable/Class/MonadLog.hs
+++ b/source/library/CabalGild/Unstable/Class/MonadLog.hs
@@ -3,19 +3,22 @@ module CabalGild.Unstable.Class.MonadLog where
 import qualified CabalGild.Unstable.Type.Severity as Severity
 import qualified System.IO as IO
 
--- | A 'Monad' that can also log messages.
+-- | A 'Monad' that can also log messages of a given 'Severity.Severity'.
 class (Monad m) => MonadLog m where
-  -- | Logs the given message followed by a newline.
+  -- | Logs the given message at the given 'Severity.Severity' followed by a
+  -- newline.
   logLn :: Severity.Severity -> String -> m ()
 
--- | Uses 'putStrLn'.
+-- | Prints to STDOUT for 'Severity.Info' and STDERR for 'Severity.Warn'.
 instance MonadLog IO where
   logLn severity = case severity of
     Severity.Info -> IO.putStrLn
     Severity.Warn -> IO.hPutStrLn IO.stderr
 
+-- | Logs the given message at 'Severity.Info'.
 info :: (MonadLog m) => String -> m ()
 info = logLn Severity.Info
 
+-- | Logs the given message at 'Severity.Warn'.
 warn :: (MonadLog m) => String -> m ()
 warn = logLn Severity.Warn

--- a/source/library/CabalGild/Unstable/Class/MonadWalk.hs
+++ b/source/library/CabalGild/Unstable/Class/MonadWalk.hs
@@ -3,9 +3,14 @@ module CabalGild.Unstable.Class.MonadWalk where
 import qualified System.FilePattern as FilePattern
 import qualified System.FilePattern.Directory as FilePattern
 
--- | A wrapper around 'FilePattern.getDirectoryFilesIgnore'.
+-- | A 'Monad' that can also "walk" a directory to discover files within it.
 class (Monad m) => MonadWalk m where
+  -- | This has the same signature and semantics as
+  -- 'FilePattern.getDirectoryFilesIgnore'. The first argument is the directory
+  -- to walk. The second argument is a list of patterns to include. The third
+  -- argument is a list of patterns to exclude.
   walk :: FilePath -> [FilePattern.FilePattern] -> [FilePattern.FilePattern] -> m [FilePath]
 
+-- | Uses 'FilePattern.getDirectoryFilesIgnore'.
 instance MonadWalk IO where
   walk = FilePattern.getDirectoryFilesIgnore

--- a/source/library/CabalGild/Unstable/Class/Warning.hs
+++ b/source/library/CabalGild/Unstable/Class/Warning.hs
@@ -1,0 +1,6 @@
+module CabalGild.Unstable.Class.Warning where
+
+-- | A warning, which is similar to an 'Control.Exception.Exception'.
+class (Show w) => Warning w where
+  displayWarning :: w -> String
+  displayWarning = show

--- a/source/library/CabalGild/Unstable/Extra/CharParsing.hs
+++ b/source/library/CabalGild/Unstable/Extra/CharParsing.hs
@@ -3,8 +3,10 @@ module CabalGild.Unstable.Extra.CharParsing where
 import qualified Distribution.Compat.CharParsing as Parse
 import qualified Distribution.Parsec as Parsec
 
+-- | Wraps the given parser in parentheses.
 parens :: (Parsec.CabalParsing m) => m a -> m a
 parens = Parse.between (token "(") (token ")")
 
+-- | Parses the given string followed by any amount of blank space.
 token :: (Parsec.CabalParsing m) => String -> m ()
 token s = Parse.string s *> Parse.spaces

--- a/source/library/CabalGild/Unstable/Extra/FilePath.hs
+++ b/source/library/CabalGild/Unstable/Extra/FilePath.hs
@@ -1,0 +1,11 @@
+module CabalGild.Unstable.Extra.FilePath where
+
+import qualified System.FilePath.Posix as Posix
+import qualified System.FilePath.Windows as Windows
+
+-- | Converts a 'FilePath' with potential Windows-style separators in it to one
+-- with only POSIX-style separators.
+toPosixSeparators :: FilePath -> FilePath
+toPosixSeparators =
+  Posix.joinPath
+    . Windows.splitDirectories

--- a/source/library/CabalGild/Unstable/Main.hs
+++ b/source/library/CabalGild/Unstable/Main.hs
@@ -13,6 +13,7 @@ import qualified CabalGild.Unstable.Class.MonadLog as MonadLog
 import qualified CabalGild.Unstable.Class.MonadRead as MonadRead
 import qualified CabalGild.Unstable.Class.MonadWalk as MonadWalk
 import qualified CabalGild.Unstable.Class.MonadWrite as MonadWrite
+import qualified CabalGild.Unstable.Class.Warning as Warning
 import qualified CabalGild.Unstable.Exception.CheckFailure as CheckFailure
 import qualified CabalGild.Unstable.Exception.ParseError as ParseError
 import qualified CabalGild.Unstable.Extra.ByteString as ByteString
@@ -66,7 +67,7 @@ mainWith ::
   m ()
 mainWith arguments = do
   (flags, w1) <- Writer.runWriterT $ Flag.fromArguments arguments
-  Foldable.traverse_ (MonadLog.warn . mappend "WARNING: ") w1
+  Foldable.traverse_ (MonadLog.warn . mappend "WARNING: " . Warning.displayWarning) w1
   (config, w2) <- Writer.runWriterT $ Config.fromFlags flags
   Foldable.traverse_ (MonadLog.warn . mappend "WARNING: ") w2
   context <- Context.fromConfig config

--- a/source/library/CabalGild/Unstable/Main.hs
+++ b/source/library/CabalGild/Unstable/Main.hs
@@ -25,7 +25,9 @@ import qualified CabalGild.Unstable.Type.Mode as Mode
 import qualified CabalGild.Unstable.Type.Output as Output
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
+import qualified Control.Monad.Writer as Writer
 import qualified Data.ByteString as ByteString
+import qualified Data.Foldable as Foldable
 import qualified Distribution.Fields as Fields
 import qualified System.Environment as Environment
 import qualified System.Exit as Exit
@@ -63,8 +65,10 @@ mainWith ::
   [String] ->
   m ()
 mainWith arguments = do
-  flags <- Flag.fromArguments arguments
-  config <- Config.fromFlags flags
+  (flags, w1) <- Writer.runWriterT $ Flag.fromArguments arguments
+  Foldable.traverse_ (MonadLog.warn . mappend "WARNING: ") w1
+  (config, w2) <- Writer.runWriterT $ Config.fromFlags flags
+  Foldable.traverse_ (MonadLog.warn . mappend "WARNING: ") w2
   context <- Context.fromConfig config
 
   input <- MonadRead.read $ Context.input context

--- a/source/library/CabalGild/Unstable/Type/Condition.hs
+++ b/source/library/CabalGild/Unstable/Type/Condition.hs
@@ -43,7 +43,7 @@ parseCondition parseVariable = Parsec.PP $ \csv -> do
       )
       csv
 
--- Parses a literal 'Condition'.
+-- | Parses a literal 'Condition'.
 parseLit :: (Parsec.CabalParsing m) => m Bool
 parseLit =
   Parse.choice

--- a/source/library/CabalGild/Unstable/Type/Condition.hs
+++ b/source/library/CabalGild/Unstable/Type/Condition.hs
@@ -9,6 +9,8 @@ import qualified Text.Parsec as P
 import qualified Text.Parsec.Expr as PE
 import qualified Text.PrettyPrint as PrettyPrint
 
+-- | Similar to 'Distribution.Types.Condition.Condition', but retains
+-- information about parentheses.
 data Condition a
   = Par (Condition a)
   | Not (Condition a)
@@ -18,6 +20,9 @@ data Condition a
   | Var a
   deriving (Eq, Show)
 
+-- | Similar to 'Distribution.Fields.ConfVar.parseConditionConfVar', but
+-- parameterized on the variable parser. Also it's a normal parser rather than
+-- a function on section arguments.
 parseCondition :: Parsec.ParsecParser a -> Parsec.ParsecParser (Condition a)
 parseCondition parseVariable = Parsec.PP $ \csv -> do
   let operators :: (P.Stream s m Char) => PE.OperatorTable s u m (Condition b)
@@ -38,6 +43,7 @@ parseCondition parseVariable = Parsec.PP $ \csv -> do
       )
       csv
 
+-- Parses a literal 'Condition'.
 parseLit :: (Parsec.CabalParsing m) => m Bool
 parseLit =
   Parse.choice
@@ -47,6 +53,8 @@ parseLit =
       False <$ Parse.token "false"
     ]
 
+-- | Pretty-prints a 'Condition' using the given pretty-printer for the
+-- variables.
 prettyCondition :: (a -> PrettyPrint.Doc) -> Condition a -> PrettyPrint.Doc
 prettyCondition f x =
   case x of

--- a/source/library/CabalGild/Unstable/Type/Config.hs
+++ b/source/library/CabalGild/Unstable/Type/Config.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 -- | This module defines the 'Config' data type.
 module CabalGild.Unstable.Type.Config where
 
@@ -9,6 +11,8 @@ import qualified CabalGild.Unstable.Type.Optional as Optional
 import qualified CabalGild.Unstable.Type.Output as Output
 import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
+import qualified Control.Monad.Writer as Writer
+import qualified Data.Sequence as Seq
 
 -- | This data type represents the configuration for the command line utility.
 -- Each field typically corresponds to a flag.
@@ -37,27 +41,69 @@ initial =
     }
 
 -- | Applies a flag to the config, returning the new config.
-applyFlag :: (Exception.MonadThrow m) => Config -> Flag.Flag -> m Config
+applyFlag ::
+  (Exception.MonadThrow m, Writer.MonadWriter (Seq.Seq String) m) =>
+  Config -> Flag.Flag -> m Config
 applyFlag config flag = case flag of
   Flag.CRLF s -> do
     l <- Leniency.fromString s
+    forSpecific (crlf config) $ \old ->
+      Writer.tell
+        . Seq.singleton
+        $ unwords ["changing --crlf from", show old, "to", show l]
     pure config {crlf = Optional.Specific l}
   Flag.Help b -> pure config {help = Optional.Specific b}
-  Flag.Input s -> pure config {input = Optional.Specific $ Input.fromString s}
-  Flag.IO s ->
+  Flag.Input s -> do
+    forSpecific (input config) $ \old ->
+      Writer.tell
+        . Seq.singleton
+        $ unwords ["changing --input from", show old, "to", show s]
+    pure config {input = Optional.Specific $ Input.fromString s}
+  Flag.IO s -> do
+    forSpecific (input config) $ \old ->
+      Writer.tell
+        . Seq.singleton
+        $ unwords ["changing --input from", show old, "to", show s]
+    forSpecific (output config) $ \old ->
+      Writer.tell
+        . Seq.singleton
+        $ unwords ["changing --output from", show old, "to", show s]
     pure
       config
         { input = Optional.Specific $ Input.fromString s,
           output = Optional.Specific $ Output.fromString s
         }
   Flag.Mode s -> do
+    forSpecific (mode config) $ \old ->
+      Writer.tell
+        . Seq.singleton
+        $ unwords ["changing --mode from", show old, "to", show s]
     m <- Mode.fromString s
     pure config {mode = Optional.Specific m}
-  Flag.Output s -> pure config {output = Optional.Specific $ Output.fromString s}
-  Flag.Stdin s -> pure config {stdin = Optional.Specific s}
+  Flag.Output s -> do
+    forSpecific (output config) $ \old ->
+      Writer.tell
+        . Seq.singleton
+        $ unwords ["changing --output from", show old, "to", show s]
+    pure config {output = Optional.Specific $ Output.fromString s}
+  Flag.Stdin s -> do
+    forSpecific (stdin config) $ \old ->
+      Writer.tell
+        . Seq.singleton
+        $ unwords ["changing --stdin from", show old, "to", show s]
+    pure config {stdin = Optional.Specific s}
   Flag.Version b -> pure config {version = Optional.Specific b}
+
+forSpecific ::
+  (Applicative f) =>
+  Optional.Optional a -> (a -> f ()) -> f ()
+forSpecific o f = case o of
+  Optional.Default -> pure ()
+  Optional.Specific x -> f x
 
 -- | Converts a list of flags into a config by starting with 'initial' and
 -- repeatedly calling 'applyFlag'.
-fromFlags :: (Exception.MonadThrow m) => [Flag.Flag] -> m Config
+fromFlags ::
+  (Exception.MonadThrow m, Writer.MonadWriter (Seq.Seq String) m) =>
+  [Flag.Flag] -> m Config
 fromFlags = Monad.foldM applyFlag initial

--- a/source/library/CabalGild/Unstable/Type/Context.hs
+++ b/source/library/CabalGild/Unstable/Type/Context.hs
@@ -14,6 +14,7 @@ import qualified Control.Monad as Monad
 import qualified Control.Monad.Catch as Exception
 import qualified Data.Char as Char
 import qualified Data.List as List
+import qualified Data.Maybe as Maybe
 import qualified Data.Version as Version
 import qualified Paths_cabal_gild as This
 import qualified System.Console.GetOpt as GetOpt
@@ -40,7 +41,7 @@ fromConfig ::
 fromConfig config = do
   let version = Version.showVersion This.version
 
-  Monad.when (Optional.withDefault False $ Config.help config) $ do
+  Monad.when (Maybe.fromMaybe False . Optional.toMaybe $ Config.help config) $ do
     let header =
           unlines
             [ "cabal-gild version " <> version,
@@ -52,7 +53,7 @@ fromConfig config = do
       $ GetOpt.usageInfo header Flag.options
     Exception.throwM Exit.ExitSuccess
 
-  Monad.when (Optional.withDefault False $ Config.version config) $ do
+  Monad.when (Maybe.fromMaybe False . Optional.toMaybe $ Config.version config) $ do
     MonadLog.info version
     Exception.throwM Exit.ExitSuccess
 
@@ -66,15 +67,15 @@ fromConfig config = do
       Exception.throwM SpecifiedOutputWithCheckMode.SpecifiedOutputWithCheckMode
     _ -> pure ()
 
-  let theInput = Optional.withDefault Input.Stdin $ Config.input config
+  let theInput = Maybe.fromMaybe Input.Stdin . Optional.toMaybe $ Config.input config
       filePath = case theInput of
         Input.Stdin -> "."
         Input.File f -> f
   pure
     Context
-      { crlf = Optional.withDefault Leniency.Lenient $ Config.crlf config,
+      { crlf = Maybe.fromMaybe Leniency.Lenient . Optional.toMaybe $ Config.crlf config,
         input = theInput,
-        mode = Optional.withDefault Mode.Format $ Config.mode config,
-        output = Optional.withDefault Output.Stdout $ Config.output config,
-        stdin = Optional.withDefault filePath $ Config.stdin config
+        mode = Maybe.fromMaybe Mode.Format . Optional.toMaybe $ Config.mode config,
+        output = Maybe.fromMaybe Output.Stdout . Optional.toMaybe $ Config.output config,
+        stdin = Maybe.fromMaybe filePath . Optional.toMaybe $ Config.stdin config
       }

--- a/source/library/CabalGild/Unstable/Type/Context.hs
+++ b/source/library/CabalGild/Unstable/Type/Context.hs
@@ -47,13 +47,13 @@ fromConfig config = do
               "",
               "<https://github.com/tfausak/cabal-gild>"
             ]
-    MonadLog.logLn
+    MonadLog.info
       . List.dropWhileEnd Char.isSpace
       $ GetOpt.usageInfo header Flag.options
     Exception.throwM Exit.ExitSuccess
 
   Monad.when (Optional.withDefault False $ Config.version config) $ do
-    MonadLog.logLn version
+    MonadLog.info version
     Exception.throwM Exit.ExitSuccess
 
   case (Config.input config, Config.stdin config) of

--- a/source/library/CabalGild/Unstable/Type/DiscoverTarget.hs
+++ b/source/library/CabalGild/Unstable/Type/DiscoverTarget.hs
@@ -1,6 +1,11 @@
 module CabalGild.Unstable.Type.DiscoverTarget where
 
+-- | This type determines the type of thing to search for when using the
+-- @discover@ pragma.
 data DiscoverTarget
-  = Files
-  | Modules
+  = -- | Discovers any file at all.
+    Files
+  | -- | Discovers only Haskell modules, which also includes signatures and
+    -- various pre-processors.
+    Modules
   deriving (Eq, Show)

--- a/source/library/CabalGild/Unstable/Type/Flag.hs
+++ b/source/library/CabalGild/Unstable/Type/Flag.hs
@@ -3,8 +3,9 @@
 module CabalGild.Unstable.Type.Flag where
 
 import qualified CabalGild.Unstable.Exception.InvalidOption as InvalidOption
-import qualified CabalGild.Unstable.Exception.UnexpectedArgument as UnexpectedArgument
-import qualified CabalGild.Unstable.Exception.UnknownOption as UnknownOption
+import qualified CabalGild.Unstable.Type.SomeWarning as SomeWarning
+import qualified CabalGild.Unstable.Warning.UnexpectedArgument as UnexpectedArgument
+import qualified CabalGild.Unstable.Warning.UnknownOption as UnknownOption
 import qualified Control.Monad.Catch as Exception
 import qualified Control.Monad.Writer as Writer
 import qualified Data.Foldable as Foldable
@@ -83,11 +84,11 @@ options =
 -- | Converts a list of command line arguments into a list of flags. If there
 -- are any invalid options an exception will be thrown.
 fromArguments ::
-  (Exception.MonadThrow m, Writer.MonadWriter (Seq.Seq String) m) =>
+  (Exception.MonadThrow m, Writer.MonadWriter (Seq.Seq SomeWarning.SomeWarning) m) =>
   [String] -> m [Flag]
 fromArguments arguments = do
   let (flgs, args, opts, errs) = GetOpt.getOpt' GetOpt.Permute options arguments
-  Foldable.traverse_ (Writer.tell . Seq.singleton . Exception.displayException . UnexpectedArgument.fromString) args
-  Foldable.traverse_ (Writer.tell . Seq.singleton . Exception.displayException . UnknownOption.fromString) opts
+  Foldable.traverse_ (Writer.tell . Seq.singleton . SomeWarning.SomeWarning . UnexpectedArgument.fromString) args
+  Foldable.traverse_ (Writer.tell . Seq.singleton . SomeWarning.SomeWarning . UnknownOption.fromString) opts
   Foldable.traverse_ (Exception.throwM . InvalidOption.fromString) errs
   pure flgs

--- a/source/library/CabalGild/Unstable/Type/Flag.hs
+++ b/source/library/CabalGild/Unstable/Type/Flag.hs
@@ -88,6 +88,6 @@ fromArguments ::
 fromArguments arguments = do
   let (flgs, args, opts, errs) = GetOpt.getOpt' GetOpt.Permute options arguments
   Foldable.traverse_ (Writer.tell . Seq.singleton . Exception.displayException . UnexpectedArgument.fromString) args
-  Foldable.traverse_ (Exception.throwM . InvalidOption.fromString) errs
   Foldable.traverse_ (Writer.tell . Seq.singleton . Exception.displayException . UnknownOption.fromString) opts
+  Foldable.traverse_ (Exception.throwM . InvalidOption.fromString) errs
   pure flgs

--- a/source/library/CabalGild/Unstable/Type/Input.hs
+++ b/source/library/CabalGild/Unstable/Type/Input.hs
@@ -13,3 +13,8 @@ fromString :: String -> Input
 fromString s = case s of
   "-" -> Stdin
   _ -> File s
+
+toString :: Input -> String
+toString i = case i of
+  Stdin -> "-"
+  File s -> s

--- a/source/library/CabalGild/Unstable/Type/Input.hs
+++ b/source/library/CabalGild/Unstable/Type/Input.hs
@@ -13,8 +13,3 @@ fromString :: String -> Input
 fromString s = case s of
   "-" -> Stdin
   _ -> File s
-
-toString :: Input -> String
-toString i = case i of
-  Stdin -> "-"
-  File s -> s

--- a/source/library/CabalGild/Unstable/Type/Mixin.hs
+++ b/source/library/CabalGild/Unstable/Type/Mixin.hs
@@ -24,6 +24,7 @@ instance Parsec.Parsec Mixin where
 instance Pretty.Pretty Mixin where
   pretty = Pretty.pretty . unwrap
 
+-- | Sorts the 'Mixin.mixinIncludeRenaming' field using 'sortIncludeRenaming'.
 sortMixin :: Mixin.Mixin -> Mixin.Mixin
 sortMixin x =
   Mixin.Mixin
@@ -32,6 +33,8 @@ sortMixin x =
       Mixin.mixinIncludeRenaming = sortIncludeRenaming $ Mixin.mixinIncludeRenaming x
     }
 
+-- | Sorts both 'IncludeRenaming.includeProvidesRn' and
+-- 'IncludeRenaming.includeRequiresRn' fields using 'sortModuleRenaming'.
 sortIncludeRenaming :: IncludeRenaming.IncludeRenaming -> IncludeRenaming.IncludeRenaming
 sortIncludeRenaming x =
   IncludeRenaming.IncludeRenaming
@@ -39,6 +42,8 @@ sortIncludeRenaming x =
       IncludeRenaming.includeRequiresRn = sortModuleRenaming $ IncludeRenaming.includeRequiresRn x
     }
 
+-- | Sorts both 'ModuleRenaming.HidingRenaming' and
+-- 'ModuleRenaming.ModuleRenaming' variants.
 sortModuleRenaming :: ModuleRenaming.ModuleRenaming -> ModuleRenaming.ModuleRenaming
 sortModuleRenaming x = case x of
   ModuleRenaming.DefaultRenaming -> ModuleRenaming.DefaultRenaming

--- a/source/library/CabalGild/Unstable/Type/Optional.hs
+++ b/source/library/CabalGild/Unstable/Type/Optional.hs
@@ -8,13 +8,12 @@ data Optional a
   | Specific a
   deriving (Eq, Show)
 
--- | Uses the provided default value if the optional is 'Default', otherwise
--- gets the value out of the 'Specific'. Similar to 'Data.Maybe.fromMaybe'.
-withDefault :: a -> Optional a -> a
-withDefault = flip optional id
+-- | Converts a 'Maybe' value into an 'Optional' one.
+fromMaybe :: Maybe a -> Optional a
+fromMaybe = maybe Default Specific
 
--- | Basic destructor, similar to 'maybe'.
-optional :: b -> (a -> b) -> Optional a -> b
-optional b f o = case o of
-  Default -> b
-  Specific s -> f s
+-- | Converts an 'Optional' value into a 'Maybe' one.
+toMaybe :: Optional a -> Maybe a
+toMaybe o = case o of
+  Default -> Nothing
+  Specific s -> Just s

--- a/source/library/CabalGild/Unstable/Type/Output.hs
+++ b/source/library/CabalGild/Unstable/Type/Output.hs
@@ -13,8 +13,3 @@ fromString :: String -> Output
 fromString s = case s of
   "-" -> Stdout
   _ -> File s
-
-toString :: Output -> String
-toString o = case o of
-  Stdout -> "-"
-  File s -> s

--- a/source/library/CabalGild/Unstable/Type/Output.hs
+++ b/source/library/CabalGild/Unstable/Type/Output.hs
@@ -13,3 +13,8 @@ fromString :: String -> Output
 fromString s = case s of
   "-" -> Stdout
   _ -> File s
+
+toString :: Output -> String
+toString o = case o of
+  Stdout -> "-"
+  File s -> s

--- a/source/library/CabalGild/Unstable/Type/Severity.hs
+++ b/source/library/CabalGild/Unstable/Type/Severity.hs
@@ -1,0 +1,6 @@
+module CabalGild.Unstable.Type.Severity where
+
+data Severity
+  = Info
+  | Warn
+  deriving (Eq, Show)

--- a/source/library/CabalGild/Unstable/Type/Severity.hs
+++ b/source/library/CabalGild/Unstable/Type/Severity.hs
@@ -1,5 +1,6 @@
 module CabalGild.Unstable.Type.Severity where
 
+-- | Which level to log a message at.
 data Severity
   = Info
   | Warn

--- a/source/library/CabalGild/Unstable/Type/SomeWarning.hs
+++ b/source/library/CabalGild/Unstable/Type/SomeWarning.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module CabalGild.Unstable.Type.SomeWarning where
+
+import qualified CabalGild.Unstable.Class.Warning as Warning
+
+-- | Some particular 'Warning.Warning', wrapped up like a
+-- 'Control.Exception.SomeException'.
+data SomeWarning
+  = forall w. (Warning.Warning w) => SomeWarning w
+
+deriving instance Show SomeWarning
+
+instance Warning.Warning SomeWarning where
+  displayWarning (SomeWarning w) = Warning.displayWarning w

--- a/source/library/CabalGild/Unstable/Type/VersionRange.hs
+++ b/source/library/CabalGild/Unstable/Type/VersionRange.hs
@@ -16,6 +16,9 @@ data VersionRange a
   | Intersect (VersionRange a) (VersionRange a)
   deriving (Eq, Ord, Show)
 
+-- | Converts a 'PkgconfigVersionRange.PkgconfigVersionRange' into a
+-- 'VersionRange'. Note that the former is more expressive, so things like
+-- 'PkgconfigVersionRange.PcOrLaterVersion' will be converted into a 'Union'.
 fromPkgconfigVersionRange ::
   PkgconfigVersionRange.PkgconfigVersionRange ->
   VersionRange PkgconfigVersion.PkgconfigVersion
@@ -29,6 +32,8 @@ fromPkgconfigVersionRange x = case x of
   PkgconfigVersionRange.PcUnionVersionRanges v w -> Union (fromPkgconfigVersionRange v) (fromPkgconfigVersionRange w)
   PkgconfigVersionRange.PcIntersectVersionRanges v w -> Intersect (fromPkgconfigVersionRange v) (fromPkgconfigVersionRange w)
 
+-- | Converts a 'VersionRange.VersionRange' into a 'VersionRange'. These are
+-- isomorphic, so no information is lost.
 fromVersionRange :: VersionRange.VersionRange -> VersionRange Version.Version
 fromVersionRange =
   VersionRange.foldVersionRange

--- a/source/library/CabalGild/Unstable/Warning/UnexpectedArgument.hs
+++ b/source/library/CabalGild/Unstable/Warning/UnexpectedArgument.hs
@@ -1,0 +1,16 @@
+module CabalGild.Unstable.Warning.UnexpectedArgument where
+
+import qualified CabalGild.Unstable.Class.Warning as Warning
+
+-- | This warning is emitted when an unexpected command line argument is
+-- encountered.
+newtype UnexpectedArgument
+  = UnexpectedArgument String
+  deriving (Eq, Show)
+
+instance Warning.Warning UnexpectedArgument where
+  displayWarning (UnexpectedArgument s) = "unexpected argument: " <> s
+
+-- | Constructs an 'UnexpectedArgument' from the given 'String'.
+fromString :: String -> UnexpectedArgument
+fromString = UnexpectedArgument

--- a/source/library/CabalGild/Unstable/Warning/UnknownOption.hs
+++ b/source/library/CabalGild/Unstable/Warning/UnknownOption.hs
@@ -1,0 +1,15 @@
+module CabalGild.Unstable.Warning.UnknownOption where
+
+import qualified CabalGild.Unstable.Class.Warning as Warning
+
+-- | This warning is emitted when a command line option is not known.
+newtype UnknownOption
+  = UnknownOption String
+  deriving (Eq, Show)
+
+instance Warning.Warning UnknownOption where
+  displayWarning (UnknownOption s) = "unknown option: " <> s
+
+-- | Constructs an 'UnknownOption' from the given 'String'.
+fromString :: String -> UnknownOption
+fromString = UnknownOption


### PR DESCRIPTION
Fixes #80.

This still needs some work. 

- Rather than using `String`, there should be an actual warning type. 
- The formatting of the warnings should be a lot better. 
- There should be some tests for the warnings. 
- Some things that silently do nothing now should probably emit warnings. For example if you use an unknown pragma, currently it does nothing. Perhaps it should emit a warning. 