### PR TITLE
Add support for GHC 9.12, drop support for 9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - run: cabal configure --enable-optimization=2 --enable-tests --flags=pedantic --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
+      - run: cabal update
       - run: cabal freeze
       - run: cat cabal.project.freeze
       - run: cp cabal.project.freeze artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: mkdir artifact
-      - id: haskell
-        uses: haskell-actions/setup@v2
+      - uses: haskell/ghcup-setup@v1
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc: ${{ matrix.ghc }}
+          cabal: latest
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
       - run: cabal configure --enable-optimization=2 --enable-tests --flags=pedantic --jobs
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-          path: ${{ steps.haskell.outputs.cabal-store }}
+          path: ~/.local/state/cabal
           restore-keys: ${{ matrix.os }}-${{ matrix.ghc }}-
       - run: cabal build --only-download
       - run: cabal build --only-dependencies
@@ -37,17 +37,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: '9.10'
+          - ghc: 9.12
             os: macos-13
-          - ghc: '9.10'
+          - ghc: 9.12
             os: macos-14
-          - ghc: 9.6
-            os: ubuntu-22.04
           - ghc: 9.8
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - ghc: '9.10'
-            os: ubuntu-22.04
-          - ghc: '9.10'
+            os: ubuntu-24.04
+          - ghc: 9.12
+            os: ubuntu-24.04
+          - ghc: 9.12
             os: windows-2022
   cabal:
     name: Cabal
@@ -80,15 +80,15 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
       - run: sh -exc 'for d in *; do cd $d; tar --extract --file artifact.tar --verbose; cd ..; done'
-      - run: cp cabal-gild-${{ github.sha }}-ghc-9.10-ubuntu-22.04/artifact/${{ env.PREFIX }}.tar.gz .
+      - run: cp cabal-gild-${{ github.sha }}-ghc-9.12-ubuntu-24.04/artifact/${{ env.PREFIX }}.tar.gz .
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-darwin-x64.tar.gz --verbose cabal-gild
-        working-directory: cabal-gild-${{ github.sha }}-ghc-9.10-macos-13/artifact
+        working-directory: cabal-gild-${{ github.sha }}-ghc-9.12-macos-13/artifact
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-darwin-arm64.tar.gz --verbose cabal-gild
-        working-directory: cabal-gild-${{ github.sha }}-ghc-9.10-macos-14/artifact
+        working-directory: cabal-gild-${{ github.sha }}-ghc-9.12-macos-14/artifact
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-linux-x64.tar.gz --verbose cabal-gild
-        working-directory: cabal-gild-${{ github.sha }}-ghc-9.10-ubuntu-22.04/artifact
+        working-directory: cabal-gild-${{ github.sha }}-ghc-9.12-ubuntu-24.04/artifact
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-win32-x64.tar.gz --verbose cabal-gild.exe
-        working-directory: cabal-gild-${{ github.sha }}-ghc-9.10-windows-2022/artifact
+        working-directory: cabal-gild-${{ github.sha }}-ghc-9.12-windows-2022/artifact
       - uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.PREFIX }}*.tar.gz

--- a/cabal-gild.cabal
+++ b/cabal-gild.cabal
@@ -22,7 +22,7 @@ flag pedantic
   manual: True
 
 common library
-  build-depends: base ^>=4.18.0.0 || ^>=4.19.0.0 || ^>=4.20.0.0
+  build-depends: base ^>=4.19.0.0 || ^>=4.20.0.0 || ^>=4.21.0.0
   default-language: Haskell2010
   ghc-options:
     -Weverything
@@ -33,13 +33,11 @@ common library
     -Wno-missing-export-lists
     -Wno-missing-import-lists
     -Wno-missing-kind-signatures
+    -Wno-missing-role-annotations
     -Wno-missing-safe-haskell-mode
     -Wno-prepositive-qualified-module
     -Wno-safe
     -Wno-unsafe
-
-  if impl(ghc >=9.8)
-    ghc-options: -Wno-missing-role-annotations
 
   if flag(pedantic)
     ghc-options: -Werror
@@ -55,7 +53,7 @@ library
   import: library
   autogen-modules: Paths_cabal_gild
   build-depends:
-    Cabal-syntax ^>=3.10.1.0 || ^>=3.12.0.0,
+    Cabal-syntax ^>=3.10.1.0 || ^>=3.12.0.0 || ^>=3.14.0.0,
     bytestring ^>=0.11.4.0 || ^>=0.12.0.2,
     containers ^>=0.6.7 || ^>=0.7,
     exceptions ^>=0.10.7,


### PR DESCRIPTION
Also switch from [haskell-actions/setup](https://github.com/haskell-actions/setup) to [haskell/ghcup-setup](https://github.com/haskell/ghcup-setup).