### PR TITLE
Update CI workflow to remove macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
       matrix:
         include:
           - ghc: 9.12
-            os: macos-13
-          - ghc: 9.12
             os: macos-14
           - ghc: 9.8
             os: ubuntu-24.04


### PR DESCRIPTION
Removed macOS 13 from CI workflow matrix.