### PR TITLE
Change how trailing comments are formatted

### DIFF
--- a/source/library/CabalGild/Unstable/Action/AttachComments.hs
+++ b/source/library/CabalGild/Unstable/Action/AttachComments.hs
@@ -1,44 +1,74 @@
 module CabalGild.Unstable.Action.AttachComments where
 
+import qualified CabalGild.Unstable.Extra.Name as Name
 import qualified CabalGild.Unstable.Type.Comment as Comment
 import qualified CabalGild.Unstable.Type.Comments as Comments
 import qualified Control.Monad.Trans.State as StateT
 import qualified Distribution.Fields as Fields
+import qualified Distribution.Parsec.Position as Position
 
--- | High level wrapper around 'field' that makes this action easier to compose
+-- | High level wrapper around 'fields' that makes this action easier to compose
 -- with other actions.
 run ::
-  (Applicative m, Ord p) =>
-  ([Fields.Field p], [Comment.Comment p]) ->
-  m ([Fields.Field (p, Comments.Comments p)], [Comment.Comment p])
-run (fs, cs) = pure $ StateT.runState (traverse field fs) cs
+  (Applicative m) =>
+  ([Fields.Field Position.Position], [Comment.Comment Position.Position]) ->
+  m ([Fields.Field (Position.Position, Comments.Comments Position.Position)], [Comment.Comment Position.Position])
+run (fs, cs) = pure $ StateT.runState (fields Nothing fs) cs
+
+-- | Attaches comments to a list of fields, with awareness of sibling positions.
+-- The first argument is the boundary position (e.g., from a parent's next sibling).
+fields ::
+  Maybe Position.Position ->
+  [Fields.Field Position.Position] ->
+  StateT.State [Comment.Comment Position.Position] [Fields.Field (Position.Position, Comments.Comments Position.Position)]
+fields _ [] = pure []
+fields boundary (f : rest) = do
+  let nextPos = case rest of
+        [] -> boundary
+        (next : _) -> Just $ fieldPosition next
+  f' <- field nextPos f
+  rest' <- fields boundary rest
+  pure (f' : rest')
+
+-- | Gets the position of a field (from its name).
+fieldPosition :: Fields.Field Position.Position -> Position.Position
+fieldPosition f = case f of
+  Fields.Field n _ -> Name.annotation n
+  Fields.Section n _ _ -> Name.annotation n
 
 -- | Attaches comments to a single field. It is assumed that both the fields
--- and comments are already sorted by their position @p@. This precondition is
+-- and comments are already sorted by their position. This precondition is
 -- not checked. Note that comments actually end up attached to the field's
 -- name. That's because the 'Field.Field' type doesn't have any annotations
 -- directly on it.
+--
+-- Comments that are indented beyond the field's starting column are attached
+-- as trailing comments (in 'Comments.after'), but only if they appear before
+-- the next sibling's position.
 field ::
-  (Ord p) =>
-  Fields.Field p ->
-  StateT.State [Comment.Comment p] (Fields.Field (p, Comments.Comments p))
-field f = case f of
-  Fields.Field n fls ->
-    Fields.Field
-      <$> name n
-      <*> traverse fieldLine fls
-  Fields.Section n sas fs ->
-    Fields.Section
-      <$> name n
-      <*> traverse sectionArg sas
-      <*> traverse field fs
+  Maybe Position.Position ->
+  Fields.Field Position.Position ->
+  StateT.State [Comment.Comment Position.Position] (Fields.Field (Position.Position, Comments.Comments Position.Position))
+field boundary f = case f of
+  Fields.Field n fls -> do
+    let col = Position.positionCol $ Name.annotation n
+    n' <- name n
+    fls' <- traverse fieldLine fls
+    trailing <- attachTrailing col boundary
+    pure $ Fields.Field (addAfterComments n' trailing) fls'
+  Fields.Section n sas fs -> do
+    let col = Position.positionCol $ Name.annotation n
+    n' <- name n
+    sas' <- traverse sectionArg sas
+    fs' <- fields boundary fs
+    trailing <- attachTrailing col boundary
+    pure $ Fields.Section (addAfterComments n' trailing) sas' fs'
 
 -- | Attaches comments to a name. Note that this could be a field name or a
 -- section name.
 name ::
-  (Ord p) =>
-  Fields.Name p ->
-  StateT.State [Comment.Comment p] (Fields.Name (p, Comments.Comments p))
+  Fields.Name Position.Position ->
+  StateT.State [Comment.Comment Position.Position] (Fields.Name (Position.Position, Comments.Comments Position.Position))
 name (Fields.Name p fn) =
   Fields.Name
     <$> toPosition p
@@ -46,9 +76,8 @@ name (Fields.Name p fn) =
 
 -- | Attach comments to a field line.
 fieldLine ::
-  (Ord p) =>
-  Fields.FieldLine p ->
-  StateT.State [Comment.Comment p] (Fields.FieldLine (p, Comments.Comments p))
+  Fields.FieldLine Position.Position ->
+  StateT.State [Comment.Comment Position.Position] (Fields.FieldLine (Position.Position, Comments.Comments Position.Position))
 fieldLine (Fields.FieldLine p bs) =
   Fields.FieldLine
     <$> toPosition p
@@ -59,9 +88,8 @@ fieldLine (Fields.FieldLine p bs) =
 -- must be on the same line as the section name, so all comments will end up
 -- attached to the name.
 sectionArg ::
-  (Ord p) =>
-  Fields.SectionArg p ->
-  StateT.State [Comment.Comment p] (Fields.SectionArg (p, Comments.Comments p))
+  Fields.SectionArg Position.Position ->
+  StateT.State [Comment.Comment Position.Position] (Fields.SectionArg (Position.Position, Comments.Comments Position.Position))
 sectionArg sa = case sa of
   Fields.SecArgName p bs ->
     Fields.SecArgName
@@ -80,11 +108,36 @@ sectionArg sa = case sa of
 -- Comments are attached when their position is less than or equal to the given
 -- position. The comments are removed from the state as they are attached.
 toPosition ::
-  (Ord p) =>
-  p ->
-  StateT.State [Comment.Comment p] (p, Comments.Comments p)
+  Position.Position ->
+  StateT.State [Comment.Comment Position.Position] (Position.Position, Comments.Comments Position.Position)
 toPosition p = do
   cs <- StateT.get
   let (xs, ys) = span ((<= p) . Comment.annotation) cs
   StateT.put ys
   pure (p, Comments.MkComments {Comments.before = xs, Comments.after = []})
+
+-- | Attaches trailing comments based on column indentation. Comments that are
+-- indented beyond the given column are considered trailing, but only up to
+-- the boundary position (if specified). Comments are removed from the state.
+attachTrailing ::
+  Int ->
+  Maybe Position.Position ->
+  StateT.State [Comment.Comment Position.Position] [Comment.Comment Position.Position]
+attachTrailing col boundary = do
+  cs <- StateT.get
+  let (trailing, remaining) = span isTrailing cs
+  StateT.put remaining
+  pure trailing
+  where
+    isTrailing c =
+      let pos = Comment.annotation c
+       in Position.positionCol pos > col
+            && maybe True (pos <) boundary
+
+-- | Adds trailing comments to the 'after' field of a Name's Comments.
+addAfterComments ::
+  Fields.Name (Position.Position, Comments.Comments Position.Position) ->
+  [Comment.Comment Position.Position] ->
+  Fields.Name (Position.Position, Comments.Comments Position.Position)
+addAfterComments (Fields.Name (p, cs) fn) trailing =
+  Fields.Name (p, cs {Comments.after = Comments.after cs <> trailing}) fn

--- a/source/library/CabalGild/Unstable/Action/AttachComments.hs
+++ b/source/library/CabalGild/Unstable/Action/AttachComments.hs
@@ -86,5 +86,5 @@ toPosition ::
 toPosition p = do
   cs <- StateT.get
   let (xs, ys) = span ((<= p) . Comment.annotation) $ Comments.toList cs
-  StateT.put $ Comments.fromList ys
-  pure (p, Comments.fromList xs)
+  StateT.put Comments.MkComments {Comments.before = ys, Comments.after = []}
+  pure (p, Comments.MkComments {Comments.before = xs, Comments.after = []})

--- a/source/library/CabalGild/Unstable/Action/AttachComments.hs
+++ b/source/library/CabalGild/Unstable/Action/AttachComments.hs
@@ -9,8 +9,8 @@ import qualified Distribution.Fields as Fields
 -- with other actions.
 run ::
   (Applicative m, Ord p) =>
-  ([Fields.Field p], Comments.Comments p) ->
-  m ([Fields.Field (p, Comments.Comments p)], Comments.Comments p)
+  ([Fields.Field p], [Comment.Comment p]) ->
+  m ([Fields.Field (p, Comments.Comments p)], [Comment.Comment p])
 run (fs, cs) = pure $ StateT.runState (traverse field fs) cs
 
 -- | Attaches comments to a single field. It is assumed that both the fields
@@ -21,7 +21,7 @@ run (fs, cs) = pure $ StateT.runState (traverse field fs) cs
 field ::
   (Ord p) =>
   Fields.Field p ->
-  StateT.State (Comments.Comments p) (Fields.Field (p, Comments.Comments p))
+  StateT.State [Comment.Comment p] (Fields.Field (p, Comments.Comments p))
 field f = case f of
   Fields.Field n fls ->
     Fields.Field
@@ -38,7 +38,7 @@ field f = case f of
 name ::
   (Ord p) =>
   Fields.Name p ->
-  StateT.State (Comments.Comments p) (Fields.Name (p, Comments.Comments p))
+  StateT.State [Comment.Comment p] (Fields.Name (p, Comments.Comments p))
 name (Fields.Name p fn) =
   Fields.Name
     <$> toPosition p
@@ -48,7 +48,7 @@ name (Fields.Name p fn) =
 fieldLine ::
   (Ord p) =>
   Fields.FieldLine p ->
-  StateT.State (Comments.Comments p) (Fields.FieldLine (p, Comments.Comments p))
+  StateT.State [Comment.Comment p] (Fields.FieldLine (p, Comments.Comments p))
 fieldLine (Fields.FieldLine p bs) =
   Fields.FieldLine
     <$> toPosition p
@@ -61,7 +61,7 @@ fieldLine (Fields.FieldLine p bs) =
 sectionArg ::
   (Ord p) =>
   Fields.SectionArg p ->
-  StateT.State (Comments.Comments p) (Fields.SectionArg (p, Comments.Comments p))
+  StateT.State [Comment.Comment p] (Fields.SectionArg (p, Comments.Comments p))
 sectionArg sa = case sa of
   Fields.SecArgName p bs ->
     Fields.SecArgName
@@ -82,9 +82,9 @@ sectionArg sa = case sa of
 toPosition ::
   (Ord p) =>
   p ->
-  StateT.State (Comments.Comments p) (p, Comments.Comments p)
+  StateT.State [Comment.Comment p] (p, Comments.Comments p)
 toPosition p = do
   cs <- StateT.get
-  let (xs, ys) = span ((<= p) . Comment.annotation) $ Comments.toList cs
-  StateT.put Comments.MkComments {Comments.before = ys, Comments.after = []}
+  let (xs, ys) = span ((<= p) . Comment.annotation) cs
+  StateT.put ys
   pure (p, Comments.MkComments {Comments.before = xs, Comments.after = []})

--- a/source/library/CabalGild/Unstable/Action/ExtractComments.hs
+++ b/source/library/CabalGild/Unstable/Action/ExtractComments.hs
@@ -13,9 +13,10 @@ import qualified Distribution.Parsec.Position as Position
 -- | Extracts comments from the given byte string. This is a wrapper around
 -- 'fromLine', where lines are split using 'Latin1.lines'.
 fromByteString :: ByteString.ByteString -> [Comment.Comment Position.Position]
-fromByteString = Maybe.mapMaybe (uncurry fromLine)
-          . zip [1 ..]
-          . Latin1.lines
+fromByteString =
+  Maybe.mapMaybe (uncurry fromLine)
+    . zip [1 ..]
+    . Latin1.lines
 
 -- | Extracts a comment from the given line. If the line does not contain a
 -- comment, the result will be 'Alternative.empty'.

--- a/source/library/CabalGild/Unstable/Action/ExtractComments.hs
+++ b/source/library/CabalGild/Unstable/Action/ExtractComments.hs
@@ -14,11 +14,14 @@ import qualified Distribution.Parsec.Position as Position
 -- | Extracts comments from the given byte string. This is a wrapper around
 -- 'fromLine', where lines are split using 'Latin1.lines'.
 fromByteString :: ByteString.ByteString -> Comments.Comments Position.Position
-fromByteString =
-  Comments.fromList
-    . Maybe.mapMaybe (uncurry fromLine)
-    . zip [1 ..]
-    . Latin1.lines
+fromByteString input =
+  Comments.MkComments
+    { Comments.before =
+        Maybe.mapMaybe (uncurry fromLine)
+          . zip [1 ..]
+          $ Latin1.lines input,
+      Comments.after = []
+    }
 
 -- | Extracts a comment from the given line. If the line does not contain a
 -- comment, the result will be 'Alternative.empty'.

--- a/source/library/CabalGild/Unstable/Action/ExtractComments.hs
+++ b/source/library/CabalGild/Unstable/Action/ExtractComments.hs
@@ -1,7 +1,6 @@
 module CabalGild.Unstable.Action.ExtractComments where
 
 import qualified CabalGild.Unstable.Type.Comment as Comment
-import qualified CabalGild.Unstable.Type.Comments as Comments
 import qualified Control.Applicative as Applicative
 import qualified Control.Monad as Monad
 import qualified Data.ByteString as ByteString
@@ -13,15 +12,10 @@ import qualified Distribution.Parsec.Position as Position
 
 -- | Extracts comments from the given byte string. This is a wrapper around
 -- 'fromLine', where lines are split using 'Latin1.lines'.
-fromByteString :: ByteString.ByteString -> Comments.Comments Position.Position
-fromByteString input =
-  Comments.MkComments
-    { Comments.before =
-        Maybe.mapMaybe (uncurry fromLine)
+fromByteString :: ByteString.ByteString -> [Comment.Comment Position.Position]
+fromByteString = Maybe.mapMaybe (uncurry fromLine)
           . zip [1 ..]
-          $ Latin1.lines input,
-      Comments.after = []
-    }
+          . Latin1.lines
 
 -- | Extracts a comment from the given line. If the line does not contain a
 -- comment, the result will be 'Alternative.empty'.

--- a/source/library/CabalGild/Unstable/Action/FormatFields.hs
+++ b/source/library/CabalGild/Unstable/Action/FormatFields.hs
@@ -6,6 +6,7 @@ import qualified CabalGild.Unstable.Extra.FieldLine as FieldLine
 import qualified CabalGild.Unstable.Extra.Name as Name
 import qualified CabalGild.Unstable.Extra.SectionArg as SectionArg
 import qualified CabalGild.Unstable.Extra.String as String
+import qualified CabalGild.Unstable.Type.Comment as Comment
 import qualified CabalGild.Unstable.Type.Comments as Comments
 import qualified CabalGild.Unstable.Type.Condition as Condition
 import qualified CabalGild.Unstable.Type.Dependency as Dependency
@@ -36,8 +37,8 @@ import qualified Text.PrettyPrint as PrettyPrint
 run ::
   (Applicative m) =>
   CabalSpecVersion.CabalSpecVersion ->
-  ([Fields.Field (p, Comments.Comments q)], Comments.Comments q) ->
-  m ([Fields.Field (p, Comments.Comments q)], Comments.Comments q)
+  ([Fields.Field (p, Comments.Comments q)], [Comment.Comment q]) ->
+  m ([Fields.Field (p, Comments.Comments q)], [Comment.Comment q])
 run csv (fs, cs) = pure (fmap (field csv) fs, cs)
 
 -- | Formats the given field, if applicable. Otherwise returns the field as is.

--- a/source/library/CabalGild/Unstable/Action/Render.hs
+++ b/source/library/CabalGild/Unstable/Action/Render.hs
@@ -49,7 +49,7 @@ field :: CabalSpecVersion.CabalSpecVersion -> Int -> Fields.Field (Position.Posi
 field csv i f = case f of
   Fields.Field n fls -> case fls of
     [fl]
-      | Comments.isEmpty . snd $ FieldLine.annotation fl,
+      | null . Comments.toList . snd $ FieldLine.annotation fl,
         sameRow (Name.annotation n) (FieldLine.annotation fl) ->
           comments i (snd $ Name.annotation n)
             <> ( Block.fromLine

--- a/source/library/CabalGild/Unstable/Action/Render.hs
+++ b/source/library/CabalGild/Unstable/Action/Render.hs
@@ -49,14 +49,14 @@ field :: CabalSpecVersion.CabalSpecVersion -> Int -> Fields.Field (Position.Posi
 field csv i f = case f of
   Fields.Field n fls -> case fls of
     [fl]
-      | null . Comments.toList . snd $ FieldLine.annotation fl,
+      | null . Comments.after . snd $ Name.annotation n,
+        null . Comments.toList . snd $ FieldLine.annotation fl,
         sameRow (Name.annotation n) (FieldLine.annotation fl) ->
           comments i (Comments.before . snd $ Name.annotation n)
             <> ( Block.fromLine
                    . Lens.over Line.chunkLens (mappend $ name n <> Chunk.colon)
                    $ fieldLine i fl
                )
-               <> comments (i + 1) (Comments.after . snd $ Name.annotation n)
     _ ->
       Lens.set Block.lineAfterLens (not $ null fls) $
         comments i (Comments.before . snd $ Name.annotation n)

--- a/source/library/CabalGild/Unstable/Type/Comments.hs
+++ b/source/library/CabalGild/Unstable/Type/Comments.hs
@@ -14,7 +14,7 @@ instance Semigroup (Comments p) where
   xs <> ys =
     MkComments
       { before = before xs <> before ys,
-        after = after xs <> after ys
+        after = after ys <> after xs
       }
 
 instance Monoid (Comments p) where

--- a/source/library/CabalGild/Unstable/Type/Comments.hs
+++ b/source/library/CabalGild/Unstable/Type/Comments.hs
@@ -2,7 +2,6 @@
 module CabalGild.Unstable.Type.Comments where
 
 import qualified CabalGild.Unstable.Type.Comment as Comment
-import qualified Data.Function as Function
 
 data Comments p = MkComments
   { before :: [Comment.Comment p],

--- a/source/library/CabalGild/Unstable/Type/Comments.hs
+++ b/source/library/CabalGild/Unstable/Type/Comments.hs
@@ -4,24 +4,24 @@ module CabalGild.Unstable.Type.Comments where
 import qualified CabalGild.Unstable.Type.Comment as Comment
 import qualified Data.Function as Function
 
-newtype Comments p
-  = MkComments [Comment.Comment p]
+data Comments p = MkComments
+  { before :: [Comment.Comment p],
+    after :: [Comment.Comment p]
+  }
   deriving (Eq, Show)
 
 instance Semigroup (Comments p) where
-  xs <> ys = fromList $ Function.on (<>) toList xs ys
+  xs <> ys =
+    MkComments
+      { before = before xs <> before ys,
+        after = after xs <> after ys
+      }
 
 instance Monoid (Comments p) where
   mempty = empty
 
-fromList :: [Comment.Comment p] -> Comments p
-fromList = MkComments
-
 toList :: Comments p -> [Comment.Comment p]
-toList (MkComments xs) = xs
+toList x = before x <> after x
 
 empty :: Comments p
-empty = fromList []
-
-isEmpty :: Comments p -> Bool
-isEmpty = null . toList
+empty = MkComments {before = [], after = []}

--- a/source/library/CabalGild/Unstable/Type/Comments.hs
+++ b/source/library/CabalGild/Unstable/Type/Comments.hs
@@ -2,6 +2,7 @@
 module CabalGild.Unstable.Type.Comments where
 
 import qualified CabalGild.Unstable.Type.Comment as Comment
+import qualified Distribution.Compat.Lens as Lens
 
 data Comments p = MkComments
   { before :: [Comment.Comment p],
@@ -24,3 +25,6 @@ toList x = before x <> after x
 
 empty :: Comments p
 empty = MkComments {before = [], after = []}
+
+afterLens :: Lens.Lens' (Comments p) [Comment.Comment p]
+afterLens f s = fmap (\x -> s {after = x}) . f $ after s

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -459,6 +459,21 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
         " -- c\ns"
         "-- c\ns\n"
 
+    Hspec.it "sorts inline field comments correctly" $ do
+      expectGilded
+        "-- a\n-- b\nf: 1\n -- c\n -- d"
+        "-- a\n-- b\nf:\n  1\n  -- c\n  -- d\n"
+
+    Hspec.it "sorts block field comments correctly" $ do
+      expectGilded
+        "-- a\n-- b\nf:\n -- c\n -- d\n 1\n -- e\n -- f\n 2\n -- g\n -- h"
+        "-- a\n-- b\nf:\n  -- c\n  -- d\n  -- e\n  -- f\n  1\n  2\n  -- g\n  -- h\n"
+
+    Hspec.it "sorts section comments correctly" $ do
+      expectGilded
+        "-- a\n-- b\ns\n -- c\n -- d"
+        "-- a\n-- b\ns\n  -- c\n  -- d\n"
+
   Hspec.it "formats a field without a value" $ do
     expectGilded
       "f:"

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -347,10 +347,52 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
         "f:\n 1\n -- c\n 2"
         "f:\n  -- c\n  1\n  2\n"
 
-    Hspec.it "formats a comment after a field's value" $ do
+    Hspec.it "formats a comment trailing an inline field's value" $ do
+      -- This comment is indented beyond the beginning of the field, so it
+      -- belongs to the field. That forces the field value into block mode,
+      -- even though the input was inline.
+      expectGilded
+        "f: 1\n -- c"
+        "f:\n  1\n  -- c\n"
+
+    Hspec.it "formats a comment trailing an inline field's value with an extra blank line" $ do
+      -- Even though there's an extra blank line separating the field from the
+      -- comment, the comment is still indented past the field.
+      expectGilded
+        "f: 1\n\n -- c"
+        "f:\n  1\n  -- c\n"
+
+    Hspec.it "formats a comment after an inline field's value" $ do
+      expectGilded
+        "f: 1\n-- c"
+        "f: 1\n-- c\n"
+
+    Hspec.it "formats a comment trailing a block field's value" $ do
       expectGilded
         "f:\n 1\n -- c"
+        "f:\n  1\n  -- c\n"
+
+    Hspec.it "formats a comment trailing a block field's value with an extra blank line" $ do
+      -- Same as above, but there's an extra blank line.
+      expectGilded
+        "f:\n 1\n\n -- c"
+        "f:\n  1\n  -- c\n"
+
+    Hspec.it "formats a comment after a block field's value" $ do
+      expectGilded
+        "f:\n 1\n-- c"
         "f:\n  1\n\n-- c\n"
+
+    Hspec.it "formats a comment trailing a field with multiple values" $ do
+      expectGilded
+        "f: 1\n 2\n -- c"
+        "f:\n  1\n  2\n  -- c\n"
+
+    Hspec.it "formats a comment trailing a field with multiple values with an extra blank line" $ do
+      -- Same as above, but there's an extra blank line.
+      expectGilded
+        "f: 1\n 2\n\n -- c"
+        "f:\n  1\n  2\n  -- c\n"
 
     Hspec.it "formats a comment after a field with multiple values" $ do
       expectGilded
@@ -361,6 +403,26 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       expectGilded
         "-- c\ns"
         "-- c\ns\n"
+
+    Hspec.it "formats a comment trailing a section" $ do
+      -- This comment is indented beyond the beginning of the section, so it
+      -- belongs to the section.
+      expectGilded
+        "s\n -- c"
+        "s\n  -- c\n"
+
+    Hspec.it "formats a comment trailing a section with extra blank line" $ do
+      -- Same as above, but there's an extra blank line.
+      expectGilded
+        "s\n\n -- c"
+        "s\n  -- c\n"
+
+    Hspec.it "formats a comment after a section's value" $ do
+      -- This is a minimal reproduction of the issue reported here:
+      -- <https://github.com/tfausak/cabal-gild/issues/122>.
+      expectGilded
+        "s\n f: 1\n -- c"
+        "s\n  f: 1\n  -- c\n"
 
     Hspec.it "formats a comment after a section" $ do
       expectGilded
@@ -381,6 +443,21 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       expectGilded
         "build-depends:\n >> no\n -- comment\n parse"
         "build-depends:\n  -- comment\n  >> no\n  parse\n"
+
+    Hspec.it "does not move an indented comment inside a field" $ do
+      -- Even though the comment is indented beyond the beginning of the field,
+      -- it does not belong to the field because it comes before the field.
+      expectGilded
+        " -- c\nf: 1"
+        "-- c\nf: 1\n"
+
+    Hspec.it "does not move an indented comment inside a section" $ do
+      -- Even though the comment is indented beyond the beginning of the
+      -- section, it does not belong to the section because it comes before the
+      -- section.
+      expectGilded
+        " -- c\ns"
+        "-- c\ns\n"
 
   Hspec.it "formats a field without a value" $ do
     expectGilded

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -286,45 +286,101 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       "\t\r\n \r\n"
       ""
 
-  Hspec.it "formats a comment" $ do
-    expectGilded
-      "-- c"
-      "-- c\n"
+  Hspec.describe "comments" $ do
+    Hspec.it "formats a comment" $ do
+      expectGilded
+        "-- c"
+        "-- c\n"
 
-  Hspec.it "keeps a blank comment" $ do
-    expectGilded
-      "--"
-      "--\n"
+    Hspec.it "keeps a blank comment" $ do
+      expectGilded
+        "--"
+        "--\n"
 
-  Hspec.it "formats multiple comments" $ do
-    expectGilded
-      "-- c\n-- d"
-      "-- c\n-- d\n"
+    Hspec.it "formats multiple comments" $ do
+      expectGilded
+        "-- c\n-- d"
+        "-- c\n-- d\n"
 
-  Hspec.it "removes blank lines between comments" $ do
-    expectGilded
-      "-- c\n\n-- d"
-      "-- c\n-- d\n"
+    Hspec.it "removes blank lines between comments" $ do
+      expectGilded
+        "-- c\n\n-- d"
+        "-- c\n-- d\n"
 
-  Hspec.it "does not require a space after the comment start" $ do
-    expectGilded
-      "--c"
-      "--c\n"
+    Hspec.it "does not require a space after the comment start" $ do
+      expectGilded
+        "--c"
+        "--c\n"
 
-  Hspec.it "leaves leading blank space in comments" $ do
-    expectGilded
-      "--\t c"
-      "--\t c\n"
+    Hspec.it "leaves leading blank space in comments" $ do
+      expectGilded
+        "--\t c"
+        "--\t c\n"
 
-  Hspec.it "trims trailing blank space from comments" $ do
-    expectGilded
-      "-- c\t \n"
-      "-- c\n"
+    Hspec.it "trims trailing blank space from comments" $ do
+      expectGilded
+        "-- c\t \n"
+        "-- c\n"
 
-  Hspec.it "normalizes Windows line endings in comments" $ do
-    expectGilded
-      "-- c\r\n"
-      "-- c\n"
+    Hspec.it "normalizes Windows line endings in comments" $ do
+      expectGilded
+        "-- c\r\n"
+        "-- c\n"
+
+    Hspec.it "formats a comment before a field" $ do
+      expectGilded
+        "-- c\nf: 1"
+        "-- c\nf: 1\n"
+
+    Hspec.it "formats a comment after a field" $ do
+      expectGilded
+        "f: 1\n-- c"
+        "f: 1\n-- c\n"
+
+    Hspec.it "formats a comment before a field's value" $ do
+      expectGilded
+        "f:\n -- c\n 1"
+        "f:\n  -- c\n  1\n"
+
+    Hspec.it "formats a comment in a field's value" $ do
+      expectGilded
+        "f:\n 1\n -- c\n 2"
+        "f:\n  -- c\n  1\n  2\n"
+
+    Hspec.it "formats a comment after a field's value" $ do
+      expectGilded
+        "f:\n 1\n -- c"
+        "f:\n  1\n\n-- c\n"
+
+    Hspec.it "formats a comment after a field with multiple values" $ do
+      expectGilded
+        "f: 1\n 2\n-- c"
+        "f:\n  1\n  2\n\n-- c\n"
+
+    Hspec.it "formats a comment before a section" $ do
+      expectGilded
+        "-- c\ns"
+        "-- c\ns\n"
+
+    Hspec.it "formats a comment after a section" $ do
+      expectGilded
+        "s\n-- c"
+        "s\n\n-- c\n"
+
+    Hspec.it "correctly indents a comment in a section" $ do
+      expectGilded
+        "s\n -- c\n f: 1"
+        "s\n  -- c\n  f: 1\n"
+
+    Hspec.it "floats comments on unknown fields" $ do
+      expectGilded
+        "unknown-field:\n the\n -- some comment\n value"
+        "unknown-field:\n  -- some comment\n  the\n  value\n"
+
+    Hspec.it "floats comments when parsing field fails" $ do
+      expectGilded
+        "build-depends:\n >> no\n -- comment\n parse"
+        "build-depends:\n  -- comment\n  >> no\n  parse\n"
 
   Hspec.it "formats a field without a value" $ do
     expectGilded
@@ -452,51 +508,6 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
     expectGilded
       "s\n f:\n  1\n  2"
       "s\n  f:\n    1\n    2\n"
-
-  Hspec.it "formats a comment before a field" $ do
-    expectGilded
-      "-- c\nf: 1"
-      "-- c\nf: 1\n"
-
-  Hspec.it "formats a comment after a field" $ do
-    expectGilded
-      "f: 1\n-- c"
-      "f: 1\n-- c\n"
-
-  Hspec.it "formats a comment before a field's value" $ do
-    expectGilded
-      "f:\n -- c\n 1"
-      "f:\n  -- c\n  1\n"
-
-  Hspec.it "formats a comment in a field's value" $ do
-    expectGilded
-      "f:\n 1\n -- c\n 2"
-      "f:\n  -- c\n  1\n  2\n"
-
-  Hspec.it "formats a comment after a field's value" $ do
-    expectGilded
-      "f:\n 1\n -- c"
-      "f:\n  1\n\n-- c\n"
-
-  Hspec.it "formats a comment after a field with multiple values" $ do
-    expectGilded
-      "f: 1\n 2\n-- c"
-      "f:\n  1\n  2\n\n-- c\n"
-
-  Hspec.it "formats a comment before a section" $ do
-    expectGilded
-      "-- c\ns"
-      "-- c\ns\n"
-
-  Hspec.it "formats a comment after a section" $ do
-    expectGilded
-      "s\n-- c"
-      "s\n\n-- c\n"
-
-  Hspec.it "correctly indents a comment in a section" $ do
-    expectGilded
-      "s\n -- c\n f: 1"
-      "s\n  -- c\n  f: 1\n"
 
   Hspec.describe "description" $ do
     -- These tests apply to other "free text" fields as well. The description
@@ -1582,16 +1593,6 @@ main = Hspec.hspec . Hspec.parallel . Hspec.describe "cabal-gild" $ do
       (".", [["example.txt"]])
       "-- cabal-gild: discover\nlicense-files:"
       "-- cabal-gild: discover\nlicense-files: example.txt\n"
-
-  Hspec.it "floats comments on unknown fields" $ do
-    expectGilded
-      "unknown-field:\n the\n -- some comment\n value"
-      "unknown-field:\n  -- some comment\n  the\n  value\n"
-
-  Hspec.it "floats comments when parsing field fails" $ do
-    expectGilded
-      "build-depends:\n >> no\n -- comment\n parse"
-      "build-depends:\n  -- comment\n  >> no\n  parse\n"
 
   Hspec.it "only discovers modules in given directories" $ do
     expectDiscover


### PR DESCRIPTION
Fixes #122. 

Before, Gild would only associate comments downwards. Even if you had a comment at the same indentation level, it could become un-indented. For example:

``` cabal
-- input
some-section
  some-field: some value
  -- some comment
```

``` cabal
-- old output
some-section
  some-field: some value

-- some comment
```

The new output is the same as the input. It keeps the comment nested within the section. 

This is an alternative to #142. It was still mostly authored by Claude Code, but I did some refactoring first to make the diff smaller. I also added some test cases to cover the desired behavior. 

For previous attempts, see #125 and #127. 